### PR TITLE
fixed prefire weights

### DIFF
--- a/workflows/CMS_corrections/Prefire_utils.py
+++ b/workflows/CMS_corrections/Prefire_utils.py
@@ -1,15 +1,15 @@
 def GetPrefireWeights(self, events):
     if self.era == "2016" or self.era == "2017" or self.era == "2016apv":
         if self.scouting == 1:
-            self.out_vars["prefire_nom"] = events.prefire
-            self.out_vars["prefire_up"] = events.prefireup
-            self.out_vars["prefire_down"] = events.prefiredown
+            prefire_nom = events.prefire
+            prefire_up = events.prefireup
+            prefire_down = events.prefiredown
         else:
-            self.out_vars["prefire_nom"] = events.L1PreFiringWeight.Nom
-            self.out_vars["prefire_up"] = events.L1PreFiringWeight.Up
-            self.out_vars["prefire_down"] = events.L1PreFiringWeight.Dn
+            prefire_nom = events.L1PreFiringWeight.Nom
+            prefire_up = events.L1PreFiringWeight.Up
+            prefire_down = events.L1PreFiringWeight.Dn
     else:
-        self.out_vars["prefire_nom"] = 1.0
-        self.out_vars["prefire_up"] = 1.0
-        self.out_vars["prefire_down"] = 1.0
-    return
+        prefire_nom = 1.0
+        prefire_up = 1.0
+        prefire_down = 1.0
+    return (prefire_nom, prefire_up, prefire_down)

--- a/workflows/SUEP_coffea.py
+++ b/workflows/SUEP_coffea.py
@@ -464,7 +464,10 @@ class SUEP_cluster(processor.ProcessorABC):
                     self.out_vars["PSWeight_FSR_down" + out_label] = psweights[3]
                 else:
                     self.out_vars["PSWeight" + out_label] = psweights
-                GetPrefireWeights(self, events)  # Prefire weights
+                prefireweights = GetPrefireWeights(self, events)  # Prefire weights
+                self.out_vars["prefire_nom"] = prefireweights[0]
+                self.out_vars["prefire_up"] = prefireweights[1]
+                self.out_vars["prefire_down"] = prefireweights[2]
 
         # get gen SUEP kinematics
         SUEP_genMass = len(events) * [0]

--- a/workflows/SUEP_coffea_WH.py
+++ b/workflows/SUEP_coffea_WH.py
@@ -400,6 +400,10 @@ class SUEP_cluster_WH(processor.ProcessorABC):
                     output["vars"]["PSWeight_FSR_down" + out_label] = psweights[3]
                 else:
                     output["vars"]["PSWeight" + out_label] = psweights
+                prefireweights = GetPrefireWeights(self, events)  # Prefire weights
+                output["vars"]["prefire_nom"] = prefireweights[0]
+                output["vars"]["prefire_up"] = prefireweights[1]
+                output["vars"]["prefire_down"] = prefireweights[2]
 
             output["vars"]["PV_npvs" + out_label] = events.PV.npvs
             output["vars"]["PV_npvsGood" + out_label] = events.PV.npvsGood


### PR DESCRIPTION
Prefire weights utility now returns the values of the weights, instead of assigning them directly to the dataframe, which caused issues since ggf and wh store the df differently. Unit tests successful.