### PR TITLE
Fix Lepton orthogonality, reorganize WH ntuplemaker

### DIFF
--- a/condor_SUEP_WH.py
+++ b/condor_SUEP_WH.py
@@ -45,24 +45,18 @@ def main():
     parser.add_argument("--dataset", type=str, default="X", help="")
     parser.add_argument("--maxChunks", type=int, default=None, help="")
     parser.add_argument("--chunkSize", type=int, default=100000, help="")
-    parser.add_argument("--doInf", type=str, default=-1, help="")
     options = parser.parse_args()
 
-    out_dir = os.getcwd()
     modules_era = []
 
     modules_era.append(
         SUEP_coffea_WH.SUEP_cluster_WH(
             isMC=options.isMC,
             era=str(options.era),
-            scouting=0,
             do_syst=options.doSyst,
-            syst_var="",
             sample=options.dataset,
-            weight_syst="",
             flag=False,
-            output_location=out_dir,
-            accum="pandas_merger",
+            output_location=os.getcwd(),
         )
     )
 

--- a/histmaker/README.md
+++ b/histmaker/README.md
@@ -48,6 +48,7 @@ All of these are controlled by the `config` dictionary:
 config = {
     'Cluster' : {
         'input_method' : 'CL',
+        'method_var': 'SUEP_nconst_CL',
         'xvar' :'SUEP_S1_CL',
         'xvar_regions' : [0.3, 0.4, 0.5, 1.0],
         'yvar' : 'SUEP_nconst_CL',
@@ -61,6 +62,7 @@ config = {
 
 This will:
 - Grab all ntuple variables from the input method `CL` and fill histograms in the output method `Cluster`.
+- Select all events that pass the `CL` method, using `method_var`.
 - Blind the SR for data.
 - Apply the `selections` to the DataFrame before filling the histograms.
 - Make each histogram for each ABCD region, and make an ABCD prediction for the SR.
@@ -135,10 +137,11 @@ The idea of this script is to map each of these methods to one or more set of hi
 
 1. Output tag: histograms will be named using this, and the systematics will extend each output tag (e.g. input method: CL --> output tag Cluster, with systematics Cluster_sys_up and Cluster_sys_down).
 2. `SR`: signal region definition (e.g. `[['SUEP_S1_CL', '>=', 0.5], ['SUEP_nconst_CL', '>=', 80]]`), used to blind if needed.
-3. [Optional] `selections`: a set of selections, syntax: either a list of `['variable', 'operator', value]` or a single string `"variable operator value"`. e.g. `[['ht', '>', 1200], ['ntracks > 0']]`.
-4. [Optional] `xvar/yvar`: x/y variables for ABCD method
-5. [Optional] `xvar_ragions/yvar_regions`: regions for ABCD method. N.B.: Include lower and upper bounds for all ABCD regions (e.g. `[0.0, 0.5, 1.0]`).
-6. [Optional] `new_variables`: new variables to be defined as functions of existing variables in the DataFrame, syntax: `[['new_variable_name', callable, [callable inputs]]]`.
+3. [Semi-optional] `method_var`: variable to use to select events for this method.
+4. [Optional] `selections`: a set of selections, syntax: either a list of `['variable', 'operator', value]` or a single string `"variable operator value"`. e.g. `[['ht', '>', 1200], ['ntracks > 0']]`.
+5. [Optional] `xvar/yvar`: x/y variables for ABCD method
+6. [Optional] `xvar_ragions/yvar_regions`: regions for ABCD method. N.B.: Include lower and upper bounds for all ABCD regions (e.g. `[0.0, 0.5, 1.0]`).
+7. [Optional] `new_variables`: new variables to be defined as functions of existing variables in the DataFrame, syntax: `[['new_variable_name', callable, [callable inputs]]]`.
 
 Each own input methods have their own selections, ABCD regions, and signal region. Multiple output tags can be defined for the same input method: i.e. different selections, ABCD methods, and SRs can be defined. Thus, each input method has a dictionary defined for it which is in turn stores in the `config` dictionary, with the key being the output label, e.g.
 
@@ -146,6 +149,7 @@ Each own input methods have their own selections, ABCD regions, and signal regio
 config = {
     'Cluster' : {
         'input_method' : 'CL',
+        'method_var': 'SUEP_nconst_CL',
         'xvar' :'SUEP_S1_CL',
         'xvar_regions' : [0.35, 0.4, 0.5, 1.0],
         'yvar' : 'SUEP_nconst_CL',

--- a/histmaker/fill_utils.py
+++ b/histmaker/fill_utils.py
@@ -421,19 +421,30 @@ def get_track_killing_config(config: dict) -> dict:
         label_out_new = label_out
         new_config[label_out_new] = deepcopy(config[label_out])
         new_config[label_out_new]["input_method"] += "_track_down"
-        new_config[label_out_new]["xvar"] += "_track_down"
-        new_config[label_out_new]["yvar"] += "_track_down"
-        for iSel in range(len(new_config[label_out_new]["SR"])):
-            new_config[label_out_new]["SR"][iSel][0] += "_track_down"
-        for iSel in range(len(new_config[label_out_new]["selections"])):
-            # handle some exceptions by hand, for now
-            if new_config[label_out_new]["selections"][iSel][0] in [
-                "ht",
-                "ngood_ak4jets",
-                "ht_JEC",
-            ]:
-                continue
-            new_config[label_out_new]["selections"][iSel][0] += "_track_down"
+        if "xvar" in new_config[label_out_new].keys(): new_config[label_out_new]["xvar"] += "_track_down"
+        if "yvar" in new_config[label_out_new]: new_config[label_out_new]["yvar"] += "_track_down"
+        if "method_var" in new_config[label_out_new].keys(): new_config[label_out_new]["method_var"] += "_track_down"
+        if "SR" in new_config[label_out_new].keys():
+            for iSel in range(len(new_config[label_out_new]["SR"])):
+                new_config[label_out_new]["SR"][iSel][0] += "_track_down"
+        if "selections" in new_config[label_out_new].keys():
+            for iSel in range(len(new_config[label_out_new]["selections"])):
+                if type(new_config[label_out_new]["selections"][iSel]) is str:
+                    new_config[label_out_new]["selections"][iSel] = new_config[label_out_new]["selections"][iSel].split(" ")
+                if new_config[label_out_new]["selections"][iSel][0] in [
+                    "ht",
+                    "ngood_ak4jets",
+                    "ht_JEC",
+                ]:
+                    continue
+                new_config[label_out_new]["selections"][iSel][0] += "_track_down"
+        if "new_variables" in new_config[label_out_new].keys():
+            for iVar in range(len(new_config[label_out_new]["new_variables"])):
+                vars = new_config[label_out_new]["new_variables"][iVar][2]
+                new_vars = []
+                for var in vars:
+                    if var in ["ht", "ngood_ak4jets", "ht_JEC"]: continue
+                    new_vars.append(var + "_track_down")
 
     return new_config
 

--- a/histmaker/fill_utils.py
+++ b/histmaker/fill_utils.py
@@ -216,10 +216,10 @@ def prepare_DataFrame(
     """
 
     # 1. keep only events that passed this method, if any defined
-    if config.get("xvar"):
-        if config["xvar"] not in df.columns:
+    if config.get("method_var"):
+        if config["method_var"] not in df.columns:
             return None
-        df = df[~df[config["xvar"]].isnull()]
+        df = df[~df[config["method_var"]].isnull()]
 
     # 2. blind
     if blind and not isMC:

--- a/histmaker/submit.py
+++ b/histmaker/submit.py
@@ -125,7 +125,7 @@ elif options.method == "multithread":
         getpass.getuser(), np.random.randint(0, 10000)
     )
     os.system(f"mkdir {work_dir}")
-    os.system(f"cp -a ../SUEPCoffea_dask {work_dir}/.")
+    os.system(f"cp -a ../../SUEPCoffea_dask {work_dir}/.")
     print("Working in", work_dir)
     work_dir += "/SUEPCoffea_dask/histmaker/"
     pool = Pool(

--- a/plotting/plot_utils.py
+++ b/plotting/plot_utils.py
@@ -62,7 +62,6 @@ def getColor(sample):
 
 # https://twiki.cern.ch/twiki/bin/viewauth/CMS/RA2b13TeVProduction#Dataset_luminosities_2016_pb_1
 lumis = {
-    "2016_apv": 19497.914,
     "2016apv": 19497.914,
     "2016": 16810.813,
     "2017": 41471.589,
@@ -71,7 +70,7 @@ lumis = {
 }
 
 lumis_scouting = {
-    "2016_apv": 18843.384721292190552,
+    "2016apv": 18843.384721292190552,
     "2016": 16705.324242775104523,
     "2017": 35718.640387367889404,
     "2018": 58965.346247952011108,
@@ -90,7 +89,7 @@ def lumiLabel(year, scouting=False):
     if year in ["2017", "2018"]:
         return round(lumidir[year] / 1000, 1)
     elif year == "2016":
-        return round((lumidir[year] + lumidir[year + "_apv"]) / 1000, 1)
+        return round((lumidir[year] + lumidir[year + "apv"]) / 1000, 1)
     elif year == "all":
         return round(lumidir[year] / 1000, 1)
 
@@ -110,8 +109,8 @@ def findLumiAndEra(year, auto_lumi, infile_name, scouting):
             lumi = lumidir["2017"]
             era = "2017"
         elif "20UL16MiniAODAPVv2" in infile_name:
-            lumi = lumidir["2016_apv"]
-            era = "2016_apv"
+            lumi = lumidir["2016apv"]
+            era = "2016apv"
         elif "20UL18" in infile_name:
             lumi = lumidir["2018"]
             era = "2018"

--- a/plotting/plot_utils.py
+++ b/plotting/plot_utils.py
@@ -63,6 +63,7 @@ def getColor(sample):
 # https://twiki.cern.ch/twiki/bin/viewauth/CMS/RA2b13TeVProduction#Dataset_luminosities_2016_pb_1
 lumis = {
     "2016_apv": 19497.914,
+    "2016apv": 19497.914,
     "2016": 16810.813,
     "2017": 41471.589,
     "2018": 59817.406,

--- a/workflows/SUEP_coffea_WH.py
+++ b/workflows/SUEP_coffea_WH.py
@@ -482,9 +482,11 @@ class SUEP_cluster_WH(processor.ProcessorABC):
 
         if self.isMC == 0:
             events = applyGoldenJSON(self, events)
+            events.genWeight = np.ones(len(events)) # dummy value for data
+        
         output["cutflow_goldenJSON" + out_label] += ak.sum(events.genWeight)
 
-        events = WH_utils.triggerSelection(events, output, out_label)
+        events = WH_utils.triggerSelection(events, self.era, self.isMC, output, out_label)
         output["cutflow_allTriggers" + out_label] += ak.sum(events.genWeight)
 
         events = WH_utils.qualityFiltersSelection(events, self.era)
@@ -600,6 +602,8 @@ class SUEP_cluster_WH(processor.ProcessorABC):
         # gen weights
         if self.isMC:
             output["gensumweight"] += ak.sum(events.genWeight)
+        else:
+            events.genWeight = np.ones(len(events)) # dummy value for data
 
         # run the analysis with the track systematics applied
         if self.isMC and self.do_syst:
@@ -621,7 +625,7 @@ class SUEP_cluster_WH(processor.ProcessorABC):
                     "cutflow_allTriggers_track_down": processor.value_accumulator(
                         float, 0
                     ),
-                    "curflow_orthogonality_track_down": processor.value_accumulator(
+                    "cutflow_orthogonality_track_down": processor.value_accumulator(
                         float, 0
                     ),
                     "cutflow_oneLepton_track_down": processor.value_accumulator(

--- a/workflows/WH_utils.py
+++ b/workflows/WH_utils.py
@@ -3,10 +3,108 @@ import numpy as np
 import vector
 from vector._methods import LorentzMomentum, Planar
 
-from workflows.SUEP_utils import sphericity
 
+def getAK4Jets(Jets, lepton):
+        """
+        Create awkward array of jets. Applies basic selections.
+        Returns: awkward array of dimensions (events x jets x 4 momentum)
+        """
+        Jets_awk = ak.zip(
+            {
+                "pt": Jets.pt,
+                "eta": Jets.eta,
+                "phi": Jets.phi,
+                "mass": Jets.mass,
+                "btag": Jets.btagDeepFlavB,
+                "jetId": Jets.jetId,
+                "hadronFlavour": Jets.hadronFlavour,
+                "qgl": Jets.qgl,
+            },
+            with_name="Momentum4D",
+        )
+        # jet pt cut, eta cut, and minimum separation from lepton
+        jet_awk_Cut = (
+            (Jets_awk.pt > 30)
+            & (abs(Jets_awk.eta) < 2.4)
+            & (Jets_awk.deltaR(lepton[:, 0]) >= 0.4)
+        )
+        Jets_correct = Jets_awk[jet_awk_Cut]
 
-def selectByLeptons(self, events, extraColls=[], lepveto=False):
+        return Jets_correct
+
+def getGenTracks(events):
+    genParts = events.GenPart
+    genParts = ak.zip(
+        {
+            "pt": genParts.pt,
+            "eta": genParts.eta,
+            "phi": genParts.phi,
+            "mass": genParts.mass,
+            "pdgID": genParts.pdgId,
+        },
+        with_name="Momentum4D",
+    )
+    return genParts
+
+def getTracks(events, lepton=None, leptonIsolation=None):
+    Cands = ak.zip(
+        {
+            "pt": events.PFCands.trkPt,
+            "eta": events.PFCands.trkEta,
+            "phi": events.PFCands.trkPhi,
+            "mass": events.PFCands.mass,
+            # "pdgID": events.PFCands.pdgID
+        },
+        with_name="Momentum4D",
+    )
+    cut = (
+        (events.PFCands.fromPV > 1)
+        & (events.PFCands.trkPt >= 1)
+        & (abs(events.PFCands.trkEta) <= 2.5)
+        & (abs(events.PFCands.dz) < 0.05)
+        # & (events.PFCands.dzErr < 0.05)
+        & (abs(events.PFCands.d0) < 0.05)
+        & (events.PFCands.puppiWeight > 0.1)
+    )
+    Cleaned_cands = Cands[cut]
+    Cleaned_cands = ak.packed(Cleaned_cands)
+
+    # Prepare the Lost Track collection
+    LostTracks = ak.zip(
+        {
+            "pt": events.lostTracks.pt,
+            "eta": events.lostTracks.eta,
+            "phi": events.lostTracks.phi,
+            "mass": 0.0,
+        },
+        with_name="Momentum4D",
+    )
+    cut = (
+        (events.lostTracks.fromPV > 1)
+        & (events.lostTracks.pt >= 0.1)
+        & (abs(events.lostTracks.eta) <= 2.5)
+        & (abs(events.lostTracks.dz) < 0.05)
+        & (abs(events.lostTracks.d0) < 0.05)
+        # & (events.lostTracks.dzErr < 0.05)
+        & (events.lostTracks.puppiWeight > 0.1)
+    )
+    Lost_Tracks_cands = LostTracks[cut]
+    Lost_Tracks_cands = ak.packed(Lost_Tracks_cands)
+
+    # select which tracks to use in the script
+    # dimensions of tracks = events x tracks in event x 4 momenta
+    tracks = ak.concatenate([Cleaned_cands, Lost_Tracks_cands], axis=1)
+
+    if leptonIsolation:
+        # Sorting out the tracks that overlap with the lepton
+        tracks = tracks[
+            (tracks.deltaR(lepton[:, 0]) >= leptonIsolation)
+        ]
+
+    return tracks, Cleaned_cands
+
+def getLeptons(events):
+
     ###lepton selection criteria--4momenta collection for plotting
     muons = ak.zip(
         {
@@ -26,6 +124,9 @@ def selectByLeptons(self, events, extraColls=[], lepveto=False):
             "miniIso": events.Muon.miniPFRelIso_all,
             "dxy": events.Muon.dxy,
             "dz": events.Muon.dz,
+            "charge": events.Muon.pdgId / (-13),
+            "tightId": events.Muon.tightId,
+            "pfIsoId": events.Muon.pfIsoId,
         },
         with_name="Momentum4D",
     )
@@ -48,94 +149,165 @@ def selectByLeptons(self, events, extraColls=[], lepveto=False):
             "miniIso": events.Electron.miniPFRelIso_all,
             "dxy": events.Electron.dxy,
             "dz": events.Electron.dz,
+            "charge": events.Electron.pdgId / (-11),
+            "mvaFall17V2Iso_WP80": events.Electron.mvaFall17V2Iso_WP80,
         },
         with_name="Momentum4D",
     )
 
-    ###  Some very simple selections on ID ###
-    ###  Muons: loose ID + dxy dz cuts mimicking the medium prompt ID https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideMuonIdRun2
-    ###  Electrons: loose ID + dxy dz cuts for promptness https://twiki.cern.ch/twiki/bin/view/CMS/EgammaCutBasedIdentification
-    if self.scouting == 1:
-        cutMuons = (
-            # (events.Muon.isGlobalMuon == 1 | events.Muon.isTrackerMuon == 1)
-            (events.Muon.isGlobalMuon == 1)
-            & (events.Muon.pt >= 10)
-            & (abs(events.Muon.dxy) <= 0.02)
-            & (abs(events.Muon.dz) <= 0.1)
-            & (events.Muon.trkiso < 0.10)
-            & (abs(events.Muon.eta) < 2.4)
-        )
-        cutElectrons = (
-            (events.Electron.ID == 1)
-            & (events.Electron.pt >= 15)
-            & (
-                abs(events.Electron.d0)
-                < 0.05 + 0.05 * (abs(events.Electron.eta) > 1.479)
-            )
-            & (
-                abs(events.Electron.dz)
-                < 0.10 + 0.10 * (abs(events.Electron.eta) > 1.479)
-            )
-            & ((abs(events.Electron.eta) < 1.444) | (abs(events.Electron.eta) > 1.566))
-            & (abs(events.Electron.eta) < 2.5)
-        )
-    else:
-        # "Loose" = ZH criteria, which we must impose for orthogonality
-        cutLooseMuons = (
-            (events.Muon.looseId)
-            & (events.Muon.pt >= 10)
-            & (abs(events.Muon.dxy) <= 0.02)
-            & (abs(events.Muon.dz) <= 0.1)
-            & (events.Muon.pfIsoId >= 2)
-            & (abs(events.Muon.eta) < 2.4)
-        )
-        cutLooseElectrons = (
-            (events.Electron.cutBased >= 2)
-            & (events.Electron.pt >= 15)
-            & (events.Electron.mvaFall17V2Iso_WP90)
-            & (
-                abs(events.Electron.dxy)
-                < 0.05 + 0.05 * (abs(events.Electron.eta) > 1.479)
-            )
-            & (
-                abs(events.Electron.dz)
-                < 0.10 + 0.10 * (abs(events.Electron.eta) > 1.479)
-            )
-            & ((abs(events.Electron.eta) < 1.444) | (abs(events.Electron.eta) > 1.566))
-            & (abs(events.Electron.eta) < 2.5)
-        )
+    leptons = ak.concatenate([muons, electrons], axis=1)
 
-        cutMuons = (
-            cutLooseMuons
-            & (events.Muon.tightId)
-            & (events.Muon.pfIsoId >= 5)  # PFIsoVeryTight, aka PF rel iso < 0.1
-            & (abs(events.Muon.dz) <= 0.05)
-        )
-        cutElectrons = cutLooseElectrons & (events.Electron.mvaFall17V2Iso_WP80)
+    return muons, electrons, leptons
 
-    ### Apply the cuts
-    # Object selection. selMuons contain only the events that are filtered by cutMuons criteria.
-    selMuons = muons[cutMuons]
-    selElectrons = electrons[cutElectrons]
+def getLooseLeptons(events):
+    """
+    These leptons follow EXACTLY the ZH definitions, so that we can impose 
+    orthogonality between the ZH, offline, and WH selections.
+    """
 
-    cutHasOneMuon = (ak.num(selMuons, axis=1) == 1) & (
-        ak.max(selMuons.pt, axis=1, mask_identity=False) >= 30
+    muons, electrons, leptons = getLeptons(events)
+
+    cutLooseMuons = (
+        (events.Muon.looseId)
+        & (events.Muon.pt >= 10)
+        & (abs(events.Muon.dxy) <= 0.02)
+        & (abs(events.Muon.dz) <= 0.1)
+        & (events.Muon.pfIsoId >= 2)
+        & (abs(events.Muon.eta) < 2.4)
     )
-    cutHasOneElec = (ak.num(selElectrons, axis=1) == 1) & (
-        ak.max(selElectrons.pt, axis=1, mask_identity=False) >= 35
+    cutLooseElectrons = (
+        (events.Electron.cutBased >= 2)
+        & (events.Electron.pt >= 15)
+        & (events.Electron.mvaFall17V2Iso_WP90)
+        & (
+            abs(events.Electron.dxy)
+            < 0.05 + 0.05 * (abs(events.Electron.eta) > 1.479)
+        )
+        & (
+            abs(events.Electron.dz)
+            < 0.10 + 0.10 * (abs(events.Electron.eta) > 1.479)
+        )
+        & ((abs(events.Electron.eta) < 1.444) | (abs(events.Electron.eta) > 1.566))
+        & (abs(events.Electron.eta) < 2.5)
     )
-    cutOneLep = (ak.num(selElectrons, axis=1) + ak.num(selMuons, axis=1)) < 2
-    cutHasOneLep = ((cutHasOneMuon) | (cutHasOneElec)) & cutOneLep
 
-    ### Cut the events, also return the selected leptons for operation down the line
-    events = events[cutHasOneLep]
-    selElectrons = selElectrons[cutHasOneLep]
-    selMuons = selMuons[cutHasOneLep]
+    looseMuons = muons[cutLooseMuons]
+    looseElectrons = electrons[cutLooseElectrons]
+    looseLeptons = ak.concatenate([looseMuons, looseElectrons], axis=1)
 
-    selLeptons = ak.concatenate([selElectrons, selMuons], axis=1)
+    return looseMuons, looseElectrons, looseLeptons 
 
-    return events, selLeptons  # , [coll[cutHasTwoLeps] for coll in extraColls]
+def getTightLeptons(events):
+    """
+    These leptons are the ones that will be used for the WH analysis.
+    """
 
+    looseMuons, looseElectrons, _ = getLooseLeptons(events)
+
+    # tighter lepton ID
+    cutTightMuons = (
+        (looseMuons.tightId)
+        & (looseMuons.pfIsoId >= 5)  # PFIsoVeryTight, aka PF rel iso < 0.1
+        & (abs(looseMuons.dz) <= 0.05)
+        & (looseMuons.pt >= 30)
+    )
+    cutTightElectrons = (
+        (looseElectrons.mvaFall17V2Iso_WP80)
+        & (looseElectrons.pt >= 35)
+    )
+
+    tightMuons = looseMuons[cutTightMuons]
+    tightElectrons = looseElectrons[cutTightElectrons]
+    tightLeptons = ak.concatenate([tightMuons, tightElectrons], axis=1)
+
+    return tightMuons, tightElectrons, tightLeptons
+
+def triggerSelection(events, output=None, out_label=None):
+        """
+        Applies trigger, returns events.
+        Trigger single muon and EGamma.
+        """
+
+        triggerSingleMuon = events.HLT.IsoMu27 | events.HLT.Mu50
+        triggerEGamma = (
+            events.HLT.Ele32_WPTight_Gsf
+            | events.HLT.Ele115_CaloIdVT_GsfTrkIdT
+            | events.HLT.Photon200
+        )
+
+        # this is just for cutflow
+        if output:
+            output["cutflow_triggerSingleMuon" + out_label] += ak.sum(
+                events[triggerSingleMuon].genWeight
+            )
+            output["cutflow_triggerEGamma" + out_label] += ak.sum(events[triggerEGamma].genWeight)
+
+        events = events[triggerEGamma | triggerSingleMuon]
+
+        return events
+
+def orthogonalitySelection(events):
+    """
+    This function is used to impose orthogonality between the ZH, offline, and WH selections.
+    """
+
+    # follow ZH and offline lepton definitions
+    looseMuons, looseElectrons, _ = getLooseLeptons(events)
+
+    # offline selection
+    cutAnyElecs = (ak.num(looseElectrons, axis=1) > 0) & (
+        ak.max(looseElectrons.pt, axis=1, mask_identity=False) >= 25
+    )
+    cutAnyMuons = (ak.num(looseMuons, axis=1) > 0) & (
+       ak.max(looseMuons.pt, axis=1, mask_identity=False) >= 25
+    )
+    cutAnyLeps = cutAnyElecs | cutAnyMuons
+
+    # ZH selection
+    cutHasTwoMuons = (
+        (ak.num(looseMuons, axis=1) == 2)
+        & (ak.max(looseMuons.pt, axis=1, mask_identity=False) >= 25)
+        & (ak.sum(looseMuons.charge, axis=1) == 0)
+    )
+    cutHasTwoElecs = (
+        (ak.num(looseElectrons, axis=1) == 2)
+        & (ak.max(looseElectrons.pt, axis=1, mask_identity=False) >= 25)
+        & (ak.sum(looseElectrons.charge, axis=1) == 0)
+    )
+    cutTwoLeps = (ak.num(looseElectrons, axis=1) + ak.num(looseMuons, axis=1)) < 4
+    cutHasTwoLeps = ((cutHasTwoMuons) | (cutHasTwoElecs)) & cutTwoLeps
+
+    # apply orthogonality condition
+    events = events[cutAnyLeps & ~cutHasTwoLeps]
+
+    return events
+
+def qualityFiltersSelection(events, era:str):
+    ### Apply MET filter selection (see https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2)
+    if era == "2018" or era == "2017":
+        cutAnyFilter = (
+            (events.Flag.goodVertices)
+            & (events.Flag.globalSuperTightHalo2016Filter)
+            & (events.Flag.HBHENoiseFilter)
+            & (events.Flag.HBHENoiseIsoFilter)
+            & (events.Flag.EcalDeadCellTriggerPrimitiveFilter)
+            & (events.Flag.BadPFMuonFilter)
+            & (events.Flag.BadPFMuonDzFilter)
+            & (events.Flag.eeBadScFilter)
+            & (events.Flag.ecalBadCalibFilter)
+        )
+    if era == "2016" or era == "2016apv":
+        cutAnyFilter = (
+            (events.Flag.goodVertices)
+            & (events.Flag.globalSuperTightHalo2016Filter)
+            & (events.Flag.HBHENoiseFilter)
+            & (events.Flag.HBHENoiseIsoFilter)
+            & (events.Flag.EcalDeadCellTriggerPrimitiveFilter)
+            & (events.Flag.BadPFMuonFilter)
+            & (events.Flag.BadPFMuonDzFilter)
+            & (events.Flag.eeBadScFilter)
+        )
+    return events[cutAnyFilter]
 
 def MET_delta_phi(x, MET):
     # define 4-vectors for MET (x already 4-vector)
@@ -152,7 +324,6 @@ def MET_delta_phi(x, MET):
     signed_dphi = MET_4v.deltaphi(x)
     abs_dphi = np.abs(signed_dphi)
     return abs_dphi
-
 
 def W_kinematics(lepton, MET):
     # mT calculation -- m1 = m2 = 0, e.g. MT for W uses mass_lepton = mass_MET = 0
@@ -175,121 +346,3 @@ def W_kinematics(lepton, MET):
     W_phi = np.arctan2(W_pty, W_ptx)
 
     return W_mt[:, 0], W_pt[:, 0], W_phi[:, 0]
-
-
-def HighestPTMethod(
-    self,
-    events,
-    indices,
-    tracks,
-    jets,
-    clusters,
-    output,
-    out_label=None,
-):
-    #####################################################################################
-    # ---- Highest pT Jet (PT)
-    # SUEP defined as the highest pT jet
-    #####################################################################################'
-
-    # choose highest pT jet
-    highpt_jet = ak.argsort(jets.pt, axis=1, ascending=False, stable=True)
-    jets_pTsorted = jets[highpt_jet]
-    clusters_pTsorted = clusters[highpt_jet]
-    SUEP_cand = jets_pTsorted[:, 0]
-    SUEP_cand_constituents = clusters_pTsorted[:, 0]
-
-    # at least 2 tracks
-    singleTrackCut = ak.num(SUEP_cand_constituents) > 1
-    SUEP_cand = SUEP_cand[singleTrackCut]
-    SUEP_cand_constituents = SUEP_cand_constituents[singleTrackCut]
-    tracks = tracks[singleTrackCut]
-    indices = indices[singleTrackCut]
-
-    # boost into frame of SUEP
-    boost_SUEP = ak.zip(
-        {
-            "px": SUEP_cand.px * -1,
-            "py": SUEP_cand.py * -1,
-            "pz": SUEP_cand.pz * -1,
-            "mass": SUEP_cand.mass,
-        },
-        with_name="Momentum4D",
-    )
-
-    # SUEP tracks for this method are defined to be the ones from the cluster
-    # that was picked to be the SUEP jet
-    SUEP_tracks_b = SUEP_cand_constituents.boost_p4(
-        boost_SUEP
-    )  ### boost the SUEP tracks to their restframe
-
-    # SUEP jet variables
-    eigs = sphericity(SUEP_tracks_b, 1.0)  # Set r=1.0 for IRC safe
-    output["vars"].loc(
-        indices, "SUEP_nconst_HighestPT" + out_label, ak.num(SUEP_tracks_b)
-    )
-    output["vars"].loc(
-        indices,
-        "SUEP_pt_avg_b_HighestPT" + out_label,
-        ak.mean(SUEP_tracks_b.pt, axis=-1),
-    )
-    output["vars"].loc(
-        indices, "SUEP_S1_HighestPT" + out_label, 1.5 * (eigs[:, 1] + eigs[:, 0])
-    )
-
-    # unboost for these
-    SUEP_tracks = SUEP_tracks_b.boost_p4(SUEP_cand)
-    output["vars"].loc(
-        indices, "SUEP_pt_avg_HighestPT" + out_label, ak.mean(SUEP_tracks.pt, axis=-1)
-    )
-    output["vars"].loc(indices, "SUEP_pt_HighestPT" + out_label, SUEP_cand.pt)
-    output["vars"].loc(indices, "SUEP_eta_HighestPT" + out_label, SUEP_cand.eta)
-    output["vars"].loc(indices, "SUEP_phi_HighestPT" + out_label, SUEP_cand.phi)
-    output["vars"].loc(indices, "SUEP_mass_HighestPT" + out_label, SUEP_cand.mass)
-
-    # Calculate gen SUEP and candidate SUEP differences
-    SUEP_genEta_diff_HighestPT = (
-        output["vars"]["SUEP_eta_HighestPT" + out_label]
-        - output["vars"]["SUEP_genEta" + out_label]
-    )
-    SUEP_genPhi_diff_HighestPT = (
-        output["vars"]["SUEP_phi_HighestPT" + out_label]
-        - output["vars"]["SUEP_genPhi" + out_label]
-    )
-    SUEP_genR_diff_HighestPT = (
-        SUEP_genEta_diff_HighestPT**2 + SUEP_genPhi_diff_HighestPT**2
-    ) ** 0.5
-    output["vars"][
-        "SUEP_deltaEtaGen_HighestPT" + out_label
-    ] = SUEP_genEta_diff_HighestPT
-    output["vars"][
-        "SUEP_deltaPhiGen_HighestPT" + out_label
-    ] = SUEP_genPhi_diff_HighestPT
-    output["vars"]["SUEP_deltaRGen_HighestPT" + out_label] = SUEP_genR_diff_HighestPT
-    output["vars"].loc(
-        indices,
-        "SUEP_deltaMassGen_HighestPT" + out_label,
-        (SUEP_cand.mass - output["vars"]["SUEP_genMass" + out_label][indices]),
-    )
-    output["vars"].loc(
-        indices,
-        "SUEP_deltaPtGen_HighestPT" + out_label,
-        (SUEP_cand.pt - output["vars"]["SUEP_genPt" + out_label][indices]),
-    )
-
-    # delta phi for SUEP and MET
-    output["vars"].loc(
-        indices,
-        "deltaPhi_SUEP_CaloMET" + out_label,
-        MET_delta_phi(SUEP_cand, events[indices].CaloMET),
-    )
-    output["vars"].loc(
-        indices,
-        "deltaPhi_SUEP_PuppiMET" + out_label,
-        MET_delta_phi(SUEP_cand, events[indices].PuppiMET),
-    )
-    output["vars"].loc(
-        indices,
-        "deltaPhi_SUEP_MET" + out_label,
-        MET_delta_phi(SUEP_cand, events[indices].MET),
-    )

--- a/workflows/utils/pandas_utils.py
+++ b/workflows/utils/pandas_utils.py
@@ -76,10 +76,7 @@ def format_metadata(metadata):
     Applies some formatting to efficiently store the metadata
     """
     for key in metadata.keys():
-        if (
-            "cutflow" in key
-            and type(metadata[key]) == coffea.processor.accumulator.value_accumulator
-        ):
+        if type(metadata[key]) == coffea.processor.accumulator.value_accumulator:
             metadata[key] = metadata[key].value
     return metadata
 


### PR DESCRIPTION
- reorganized WH ntuplemaker
- fixed lepton orthogonality in WH to offline and ZH
- fixed bug in submit.py for multithreading (credit: @pmlugato)
- removed some outdated and unnecessary options from condor_SUEP_WH.py and SUEPCluster class (e.g. the inference flag `doInf`)
- in `make_hists.py`, the selection of events to add to histograms for a particular method is done explicitly through `method_var` now (as opposed to before we were using the `xvar` of the ABCD method, which was an overloading that was confusing). This change is documented in `histmaker/README.md`.
- added triggers for all years (TODO: 2017 data not fixed yet)