### PR TITLE
signal flag in jsons

### DIFF
--- a/data/xsections_2016.json
+++ b/data/xsections_2016.json
@@ -2,9731 +2,11653 @@
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1118.0
+    "xsec": 1118.0,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1118.0
+    "xsec": 1118.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23630000.0
+    "xsec": 23630000.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23630000.0
+    "xsec": 23630000.0,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 108.9
+    "xsec": 108.9,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 108.9
+    "xsec": 108.9,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.93
+    "xsec": 21.93,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.93
+    "xsec": 21.93,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1554000.0
+    "xsec": 1554000.0,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1554000.0
+    "xsec": 1554000.0,
+    "signal": 0
   },
    "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30280.0
+    "xsec": 30280.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30280.0
+    "xsec": 30280.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 186100000.0
+    "xsec": 186100000.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 186100000.0
+    "xsec": 186100000.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6392.0
+    "xsec": 6392.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6392.0
+    "xsec": 6392.0,
+    "signal": 0
   },
   "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 7.465
+    "xsec": 7.465,
+    "signal": 0
   },
   "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 7.465
+    "xsec": 7.465,
+    "signal": 0
   },
   "QCD_Pt_120to170_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 407700.0
+    "xsec": 407700.0,
+    "signal": 0
   },
   "QCD_Pt_120to170_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 407700.0
+    "xsec": 407700.0,
+    "signal": 0
   },
   "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.6487
+    "xsec": 0.6487,
+    "signal": 0
   },
   "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.6487
+    "xsec": 0.6487,
+    "signal": 0
   },
   "QCD_Pt_15to30_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1244000000.0
+    "xsec": 1244000000.0,
+    "signal": 0
   },
   "QCD_Pt_15to30_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1244000000.0
+    "xsec": 1244000000.0,
+    "signal": 0
   },
   "QCD_Pt_170to300_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 103700.0
+    "xsec": 103700.0,
+    "signal": 0
   },
   "QCD_Pt_170to300_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 103700.0
+    "xsec": 103700.0,
+    "signal": 0
   },
   "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.08734
+    "xsec": 0.08734,
+    "signal": 0
   },
   "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.08734
+    "xsec": 0.08734,
+    "signal": 0
   },
   "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.005237
+    "xsec": 0.005237,
+    "signal": 0
   },
   "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.005237
+    "xsec": 0.005237,
+    "signal": 0
   },
   "QCD_Pt_300to470_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6826.0
+    "xsec": 6826.0,
+    "signal": 0
   },
   "QCD_Pt_300to470_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6826.0
+    "xsec": 6826.0,
+    "signal": 0
   },
   "QCD_Pt_30to50_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 106500000.0
+    "xsec": 106500000.0,
+    "signal": 0
   },
   "QCD_Pt_30to50_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 106500000.0
+    "xsec": 106500000.0,
+    "signal": 0
   },
   "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.0001352
+    "xsec": 0.0001352,
+    "signal": 0
   },
   "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.0001352
+    "xsec": 0.0001352,
+    "signal": 0
   },
   "QCD_Pt_470to600_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 551.2
+    "xsec": 551.2,
+    "signal": 0
   },
   "QCD_Pt_470to600_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 551.2
+    "xsec": 551.2,
+    "signal": 0
   },
   "QCD_Pt_50to80_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 15700000.0
+    "xsec": 15700000.0,
+    "signal": 0
   },
   "QCD_Pt_50to80_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 15700000.0
+    "xsec": 15700000.0,
+    "signal": 0
   },
   "QCD_Pt_600to800_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 156.7
+    "xsec": 156.7,
+    "signal": 0
   },
   "QCD_Pt_600to800_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 156.7
+    "xsec": 156.7,
+    "signal": 0
   },
   "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 26.25
+    "xsec": 26.25,
+    "signal": 0
   },
   "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 26.25
+    "xsec": 26.25,
+    "signal": 0
   },
   "QCD_Pt_80to120_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 2346000.0
+    "xsec": 2346000.0,
+    "signal": 0
   },
   "QCD_Pt_80to120_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 2346000.0
+    "xsec": 2346000.0,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1118.0
+    "xsec": 1118.0,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1118.0
+    "xsec": 1118.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23630000.0
+    "xsec": 23630000.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23630000.0
+    "xsec": 23630000.0,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 108.9
+    "xsec": 108.9,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 108.9
+    "xsec": 108.9,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.93
+    "xsec": 21.93,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.93
+    "xsec": 21.93,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1554000.0
+    "xsec": 1554000.0,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1554000.0
+    "xsec": 1554000.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30280.0
+    "xsec": 30280.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30280.0
+    "xsec": 30280.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 186100000.0
+    "xsec": 186100000.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 186100000.0
+    "xsec": 186100000.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6392.0
+    "xsec": 6392.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6392.0
-  },
-  "TTJets_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM":{
-    "xsec": 1.402,
-    "br": 1,
-    "kr": 1
-  },
-  "TTJets_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM":{
-    "xsec": 0.5581,
-    "br": 1,
-    "kr": 1
-  },
-  "TTJets_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM":{
-    "xsec": 0.09876,
-    "br": 1,
-    "kr": 1
-  },
-  "TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM":{
-    "xsec": 0.001124,
-    "br": 1,
-    "kr": 1
+    "xsec": 6392.0,
+    "signal": 0
   },
   "TTJets_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM":{
-    "xsec": 1.402,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 1.402,
+    "signal": 0
   },
   "TTJets_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM":{
-    "xsec": 0.5581,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.5581,
+    "signal": 0
   },
   "TTJets_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM":{
-    "xsec": 0.09876,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.09876,
+    "signal": 0
   },
   "TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM":{
-    "xsec": 0.001124,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.001124,
+    "signal": 0
   },
   "TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM":{
-    "xsec": 750.5,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 750.5,
+    "signal": 0
   },
   "DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6404.0
+    "xsec": 6404.0,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-0To50_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1485.0
+    "xsec": 1485.0,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-50To100_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 397.4
+    "xsec": 397.4,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 97.2
+    "xsec": 97.2,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.701
+    "xsec": 3.701,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-400To650_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5086
+    "xsec": 0.5086,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-650ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.04728
+    "xsec": 0.04728,
+    "signal": 0
   },
   "WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 0.98753,
-    "xsec": 67350.0
+    "xsec": 67350.0,
+    "signal": 0
   },
   "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 88.29
+    "xsec": 88.29,
+    "signal": 0
   },
   "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 365.34
+    "xsec": 365.34,
+    "signal": 0
   },
   "ST_tW_Dilept_5f_DR_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.289
+    "xsec": 3.289,
+    "signal": 0
   },
   "WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 11.09
+    "xsec": 11.09,
+    "signal": 0
   },
   "WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 4.664
+    "xsec": 4.664,
+    "signal": 0
   },
   "WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6.419
+    "xsec": 6.419,
+    "signal": 0
   },
   "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.9738
+    "xsec": 0.9738,
+    "signal": 0
   },
   "ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.676
+    "xsec": 3.676,
+    "signal": 0
   },
   "ZZTo4L_TuneCP5_13TeV_powheg_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1.325
+    "xsec": 1.325,
+    "signal": 0
   },
   "ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 51.1
+    "xsec": 51.1,
+    "signal": 0
   },
   "WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 412.7
+    "xsec": 412.7,
+    "signal": 0
   },
   "TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.2161
+    "xsec": 0.2161,
+    "signal": 0
   },
   "TTWJetsToQQ_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4377
+    "xsec": 0.4377,
+    "signal": 0
   },
   "TTZToQQ_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5113
+    "xsec": 0.5113,
+    "signal": 0
   },
   "TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.2439
+    "xsec": 0.2439,
+    "signal": 0
   },
   "DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 15890.0
+    "xsec": 15890.0,
+    "signal": 0
   },
   "DYJetsToLL_M-10to50_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 20460.0
+    "xsec": 20460.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1256.0
+    "xsec": 1256.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1.16
+    "xsec": 1.16,
+    "signal": 0
   },
   "WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 335.5
+    "xsec": 335.5,
+    "signal": 0
   },
   "WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.02646
+    "xsec": 0.02646,
+    "signal": 0
   },
   "WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 45.25
+    "xsec": 45.25,
+    "signal": 0
   },
   "WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 10.97
+    "xsec": 10.97,
+    "signal": 0
   },
   "WJetsToLNu_HT-70To100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1264.0
+    "xsec": 1264.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 4.933
+    "xsec": 4.933,
+    "signal": 0
   },
   "WJetsToLNu_Pt-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 763.7
+    "xsec": 763.7,
+    "signal": 0
   },
   "WJetsToLNu_Pt-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 27.55
+    "xsec": 27.55,
+    "signal": 0
   },
   "WJetsToLNu_Pt-400To600_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.477
+    "xsec": 3.477,
+    "signal": 0
   },
   "WJetsToLNu_Pt-600ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5415
+    "xsec": 0.5415,
+    "signal": 0
   },
   "WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 51.65
+    "xsec": 51.65,
+    "signal": 0
   },
   "WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 9.119
+    "xsec": 9.119,
+    "signal": 0
   },
   "WZTo1L3Nu_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.414
+    "xsec": 3.414,
+    "signal": 0
   },
   "WplusH_HToBB_WToLNu_M-125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.2832
+    "xsec": 0.2832,
+    "signal": 0
   },
   "WminusH_HToBB_WToLNu_M-125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.177
+    "xsec": 0.177,
+    "signal": 0
   },
   "ttHToNonbb_M125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5638
+    "xsec": 0.5638,
+    "signal": 0
   },
   "ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5269
+    "xsec": 0.5269,
+    "signal": 0
   },
   "GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-4cores5k_106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 8644.0
+    "xsec": 8644.0,
+    "signal": 0
   },
   "GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 2183.0
+    "xsec": 2183.0,
+    "signal": 0
   },
   "GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 260.2
+    "xsec": 260.2,
+    "signal": 0
   },
   "GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 18540.0
+    "xsec": 18540.0,
+    "signal": 0
   },
   "GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 86.58
+    "xsec": 86.58,
+    "signal": 0
   },
   "ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v3+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 67.93
+    "xsec": 67.93,
+    "signal": 0
   },
   "ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 32.51
+    "xsec": 32.51,
+    "signal": 0
   },
   "ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 32.45
+    "xsec": 32.45,
+    "signal": 0
   },
   "ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v3+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 113.4
+    "xsec": 113.4,
+    "signal": 0
   },
   "VHToNonbb_M125_TuneCP5_13TeV-amcatnloFXFX_madspin_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.935	
+    "xsec": 0.935,
+    "signal": 0	
   },
   "GluGluToSUEP_HT1000_T0p25_mS125.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS300.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS400.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS600.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS700.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS800.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS900.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS125.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS300.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS400.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS600.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS700.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS800.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS900.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS125.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS300.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS400.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS600.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS700.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS800.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS900.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS125.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS300.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS400.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS600.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS700.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS800.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS900.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS125.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS300.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS400.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS600.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS700.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS800.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS900.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS125.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS300.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS400.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS600.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS700.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS800.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS900.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS125.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS300.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS400.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS600.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS700.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS800.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS900.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS1000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS125.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS300.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS400.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS600.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS700.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS800.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS900.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS1000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS125.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS300.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS400.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS600.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS700.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS800.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS900.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS1000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS125.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS300.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS400.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS600.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS700.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS800.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS900.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS1000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS125.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS300.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS400.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS600.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS700.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS800.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS900.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS1000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS125.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS300.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS400.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS600.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS700.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS800.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS900.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS1000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
     "GluGluToSUEP_HT1000_T0p25_mS2000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS2000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS2000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS2000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS2000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS2000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T0.35_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T0.70_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T1.40_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T2.80_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T5.60_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T0.25_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T0.50_HT-1_UL16_NANOAOD": {
       "br": 1,
       "kr": 1,
-      "xsec": 0.4987
+      "xsec": 0.4987,
+      "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T1.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T8.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T0.75_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T12.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T1.50_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T3.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T6.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T1.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T16.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T8.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T16.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T8.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T0.35_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T0.70_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T1.40_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T2.80_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T5.60_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T0.50_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T1.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T8.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T0.75_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T12.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T1.50_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T3.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T6.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T1.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T16.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T8.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T16.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T8.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T0.25_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T0.50_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T1.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T0.50_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T1.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T8.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T0.75_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T12.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T1.50_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T3.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T6.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T1.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T16.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T8.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T16.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T2.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T4.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T8.00_HT-1_UL16_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T0.250_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T0.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T0.350_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T0.700_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T1.400_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T2.800_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T5.600_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T0.500_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T0.500_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T0.500_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T0.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T1.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T1.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T1.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T2.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T4.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T8.000_modegeneric ": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T8.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T0.750_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T0.750_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T0.750_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T0.750_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T1.500_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T1.500_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T1.500_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T1.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T12.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T12.000_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T12.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T12.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T3.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T3.000_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T3.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T3.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T6.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T6.000_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T6.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T6.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T1.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T1.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T1.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T16.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T16.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T16.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T16.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T2.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T4.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T8.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T8.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T16.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T16.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T16.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T16.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T2.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T32.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T32.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T32.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T32.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T4.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T8.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T8.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   }
 }

--- a/data/xsections_2016apv.json
+++ b/data/xsections_2016apv.json
@@ -2,9751 +2,11677 @@
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1118.0
+    "xsec": 1118.0,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1118.0
+    "xsec": 1118.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23630000.0
+    "xsec": 23630000.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23630000.0
+    "xsec": 23630000.0,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 108.9
+    "xsec": 108.9,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 108.9
+    "xsec": 108.9,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.93
+    "xsec": 21.93,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.93
+    "xsec": 21.93,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1554000.0
+    "xsec": 1554000.0,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1554000.0
+    "xsec": 1554000.0,
+    "signal": 0
   },
    "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30280.0
+    "xsec": 30280.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30280.0
+    "xsec": 30280.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 186100000.0
+    "xsec": 186100000.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 186100000.0
+    "xsec": 186100000.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6392.0
+    "xsec": 6392.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6392.0
+    "xsec": 6392.0,
+    "signal": 0
   },
   "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 7.465
+    "xsec": 7.465,
+    "signal": 0
   },
   "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 7.465
+    "xsec": 7.465,
+    "signal": 0
   },
   "QCD_Pt_120to170_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 407700.0
+    "xsec": 407700.0,
+    "signal": 0
   },
   "QCD_Pt_120to170_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 407700.0
+    "xsec": 407700.0,
+    "signal": 0
   },
   "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.6487
+    "xsec": 0.6487,
+    "signal": 0
   },
   "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.6487
+    "xsec": 0.6487,
+    "signal": 0
   },
   "QCD_Pt_15to30_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1244000000.0
+    "xsec": 1244000000.0,
+    "signal": 0
   },
   "QCD_Pt_15to30_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1244000000.0
+    "xsec": 1244000000.0,
+    "signal": 0
   },
   "QCD_Pt_170to300_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 103700.0
+    "xsec": 103700.0,
+    "signal": 0
   },
   "QCD_Pt_170to300_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 103700.0
+    "xsec": 103700.0,
+    "signal": 0
   },
   "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.08734
+    "xsec": 0.08734,
+    "signal": 0
   },
   "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.08734
+    "xsec": 0.08734,
+    "signal": 0
   },
   "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.005237
+    "xsec": 0.005237,
+    "signal": 0
   },
   "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.005237
+    "xsec": 0.005237,
+    "signal": 0
   },
   "QCD_Pt_300to470_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6826.0
+    "xsec": 6826.0,
+    "signal": 0
   },
   "QCD_Pt_300to470_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6826.0
+    "xsec": 6826.0,
+    "signal": 0
   },
   "QCD_Pt_30to50_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 106500000.0
+    "xsec": 106500000.0,
+    "signal": 0
   },
   "QCD_Pt_30to50_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 106500000.0
+    "xsec": 106500000.0,
+    "signal": 0
   },
   "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.0001352
+    "xsec": 0.0001352,
+    "signal": 0
   },
   "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.0001352
+    "xsec": 0.0001352,
+    "signal": 0
   },
   "QCD_Pt_470to600_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 551.2
+    "xsec": 551.2,
+    "signal": 0
   },
   "QCD_Pt_470to600_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 551.2
+    "xsec": 551.2,
+    "signal": 0
   },
   "QCD_Pt_50to80_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 15700000.0
+    "xsec": 15700000.0,
+    "signal": 0
   },
   "QCD_Pt_50to80_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 15700000.0
+    "xsec": 15700000.0,
+    "signal": 0
   },
   "QCD_Pt_600to800_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 156.7
+    "xsec": 156.7,
+    "signal": 0
   },
   "QCD_Pt_600to800_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 156.7
+    "xsec": 156.7,
+    "signal": 0
   },
   "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 26.25
+    "xsec": 26.25,
+    "signal": 0
   },
   "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 26.25
+    "xsec": 26.25,
+    "signal": 0
   },
   "QCD_Pt_80to120_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 2346000.0
+    "xsec": 2346000.0,
+    "signal": 0
   },
   "QCD_Pt_80to120_TuneCP5_13TeV_pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 2346000.0
+    "xsec": 2346000.0,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1118.0
+    "xsec": 1118.0,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1118.0
+    "xsec": 1118.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23630000.0
+    "xsec": 23630000.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23630000.0
+    "xsec": 23630000.0,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 108.9
+    "xsec": 108.9,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 108.9
+    "xsec": 108.9,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.93
+    "xsec": 21.93,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.93
+    "xsec": 21.93,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1554000.0
+    "xsec": 1554000.0,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1554000.0
+    "xsec": 1554000.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323800.0
+    "xsec": 323800.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30280.0
+    "xsec": 30280.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30280.0
+    "xsec": 30280.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 186100000.0
+    "xsec": 186100000.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 186100000.0
+    "xsec": 186100000.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6392.0
+    "xsec": 6392.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8+RunIISummer20UL16RECOAPV-106X_mcRun2_asymptotic_preVFP_v8-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6392.0
-  },
-  "TTJets_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM":{
-    "xsec": 1.402,
-    "br": 1,
-    "kr": 1
-  },
-  "TTJets_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM":{
-    "xsec": 0.5581,
-    "br": 1,
-    "kr": 1
-  },
-  "TTJets_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM":{
-    "xsec": 0.09876,
-    "br": 1,
-    "kr": 1
-  },
-  "TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM":{
-    "xsec": 0.001124,
-    "br": 1,
-    "kr": 1
+    "xsec": 6392.0,
+    "signal": 0
   },
   "TTJets_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM":{
-    "xsec": 1.402,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 1.402,
+    "signal": 0
   },
   "TTJets_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM":{
-    "xsec": 0.5581,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.5581,
+    "signal": 0
   },
   "TTJets_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM":{
-    "xsec": 0.09876,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.09876,
+    "signal": 0
   },
   "TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM":{
-    "xsec": 0.001124,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.001124,
+    "signal": 0
   },
   "TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM":{
-    "xsec": 750.5,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 750.5,
+    "signal": 0
   },
   "DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 6404.0
+    "xsec": 6404.0,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-0To50_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1485.0
+    "xsec": 1485.0,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-50To100_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 397.4
+    "xsec": 397.4,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 97.2
+    "xsec": 97.2,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.71
+    "xsec": 3.71,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-400To650_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.586
+    "xsec": 0.586,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-650ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.0728
+    "xsec": 0.0728,
+    "signal": 0
   },
   "WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 0.98753,
     "br": 1,
-    "xsec": 67350.0
+    "xsec": 67350.0,
+    "signal": 0
   },
   "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 88.29
+    "xsec": 88.29,
+    "signal": 0
   },
   "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 365.34
+    "xsec": 365.34,
+    "signal": 0
   },
   "ST_tW_Dilept_5f_DR_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.29
+    "xsec": 3.29,
+    "signal": 0
   },
   "WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 11.0
+    "xsec": 11.0,
+    "signal": 0
   },
   "WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 4.64
+    "xsec": 4.64,
+    "signal": 0
   },
   "WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 6.49
+    "xsec": 6.49,
+    "signal": 0
   },
   "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.938
+    "xsec": 0.938,
+    "signal": 0
   },
   "ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.66
+    "xsec": 3.66,
+    "signal": 0
   },
   "ZZTo4L_TuneCP5_13TeV_powheg_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1.35
+    "xsec": 1.35,
+    "signal": 0
   },
   "ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 51.1
+    "xsec": 51.1,
+    "signal": 0
   },
   "WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 412.7
+    "xsec": 412.7,
+    "signal": 0
   },
   "TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.261
+    "xsec": 0.261,
+    "signal": 0
   },
   "TTWJetsToQQ_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.477
+    "xsec": 0.477,
+    "signal": 0
   },
   "TTZToQQ_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.513
+    "xsec": 0.513,
+    "signal": 0
   },
   "TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.239
+    "xsec": 0.239,
+    "signal": 0
   },
   "DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 15890.0
+    "xsec": 15890.0,
+    "signal": 0
   },
   "DYJetsToLL_M-10to50_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 20460.0
+    "xsec": 20460.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1256.0
+    "xsec": 1256.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1.1
+    "xsec": 1.1,
+    "signal": 0
   },
   "WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1.1
+    "xsec": 1.1,
+    "signal": 0
   },
   "WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 335.5
+    "xsec": 335.5,
+    "signal": 0
   },
   "WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.0646
+    "xsec": 0.0646,
+    "signal": 0
   },
   "WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.0646
+    "xsec": 0.0646,
+    "signal": 0
   },
   "WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 0
   },
   "WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 0
   },
   "WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 10.9
+    "xsec": 10.9,
+    "signal": 0
   },
   "WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 10.9
+    "xsec": 10.9,
+    "signal": 0
   },
   "WJetsToLNu_HT-70To100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1264.0
+    "xsec": 1264.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 4.93
+    "xsec": 4.93,
+    "signal": 0
   },
   "WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 4.93
+    "xsec": 4.93,
+    "signal": 0
   },
   "WJetsToLNu_Pt-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 763.7
+    "xsec": 763.7,
+    "signal": 0
   },
   "WJetsToLNu_Pt-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 27.5
+    "xsec": 27.5,
+    "signal": 0
   },
   "WJetsToLNu_Pt-400To600_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.47
+    "xsec": 3.47,
+    "signal": 0
   },
   "WJetsToLNu_Pt-600ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.515
+    "xsec": 0.515,
+    "signal": 0
   },
   "WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 51.6
+    "xsec": 51.6,
+    "signal": 0
   },
   "WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 9.19
+    "xsec": 9.19,
+    "signal": 0
   },
   "WZTo1L3Nu_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.44
+    "xsec": 3.44,
+    "signal": 0
   },
   "WplusH_HToBB_WToLNu_M-125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.232
+    "xsec": 0.232,
+    "signal": 0
   },
   "WminusH_HToBB_WToLNu_M-125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.17
+    "xsec": 0.17,
+    "signal": 0
   },
   "ttHToNonbb_M125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.538
+    "xsec": 0.538,
+    "signal": 0
   },
   "ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.569
+    "xsec": 0.569,
+    "signal": 0
   },
   "GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-4cores5k_106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 8644.0
+    "xsec": 8644.0,
+    "signal": 0
   },
   "GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 2183.0
+    "xsec": 2183.0,
+    "signal": 0
   },
   "GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 260.2
+    "xsec": 260.2,
+    "signal": 0
   },
   "GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 18540.0
+    "xsec": 18540.0,
+    "signal": 0
   },
   "GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 86.58
+    "xsec": 86.58,
+    "signal": 0
   },
   "ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 67.9
+    "xsec": 67.9,
+    "signal": 0
   },
   "ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 32.5
+    "xsec": 32.5,
+    "signal": 0
   },
   "ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 32.4
+    "xsec": 32.4,
+    "signal": 0
   },
   "ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 113.4
+    "xsec": 113.4,
+    "signal": 0
   },
   "VHToNonbb_M125_TuneCP5_13TeV-amcatnloFXFX_madspin_pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.935	
+    "xsec": 0.935,
+    "signal": 0	
   },
   "GluGluToSUEP_HT1000_T0p25_mS125.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS300.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS400.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS600.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS700.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS800.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS900.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS125.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS300.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS400.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS600.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS700.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS800.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS900.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS125.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS300.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS400.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS600.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS700.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS800.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS900.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS125.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS300.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS400.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS600.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS700.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS800.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS900.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS125.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS300.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS400.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS600.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS700.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS800.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS900.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS125.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS300.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS400.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS600.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS700.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS800.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS900.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS125.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS300.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS400.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS600.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS700.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS800.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS900.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS1000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS125.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS300.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS400.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS600.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS700.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS800.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS900.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS1000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS125.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS300.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS400.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS600.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS700.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS800.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS900.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS1000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS125.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS300.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS400.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS600.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS700.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS800.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS900.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS1000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS125.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS300.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS400.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS600.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS700.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS800.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS900.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS1000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS125.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS300.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS400.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS600.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS700.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS800.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS900.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS1000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
     "GluGluToSUEP_HT1000_T0p25_mS2000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
-  },
+    "xsec": 0.0096,
+    "signal": 1},
+
   "GluGluToSUEP_HT1000_T0p35_mS2000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS2000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS2000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS2000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS2000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T0.35_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T0.70_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T1.40_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T2.80_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T5.60_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T0.25_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "ttHpythia_generic_M125.0_MD2.00_T0.50_HT-1_UL16APV_NANOAOD": {
       "kr": 1,
       "br": 1,
-      "xsec": 0.4987
-  },
+      "xsec": 0.4987,
+    "signal": 1
+    },
   "ttHpythia_generic_M125.0_MD2.00_T1.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T8.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T0.75_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T12.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T1.50_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T3.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T6.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T1.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T16.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T8.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T16.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T8.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T0.35_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T0.70_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T1.40_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T2.80_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T5.60_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T0.50_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T1.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T8.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T0.75_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T1.50_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T3.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T6.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T1.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T16.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T8.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T16.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T8.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T0.25_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T0.50_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T1.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T0.50_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T1.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T8.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T0.75_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T12.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T1.50_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T3.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T6.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T1.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T16.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T8.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T16.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T2.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T4.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T8.00_HT-1_UL16APV_NANOAOD": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T0.250_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T0.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T0.350_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T0.700_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T1.400_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T2.800_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T5.600_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T0.500_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T0.500_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T0.500_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T0.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T1.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T1.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T1.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T2.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T4.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T8.000_modegeneric ": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T8.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T0.750_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T0.750_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T0.750_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T0.750_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T1.500_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T1.500_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T1.500_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T1.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T12.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T12.000_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T12.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T12.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T3.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T3.000_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T3.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T3.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T6.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T6.000_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T6.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T6.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T1.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T1.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T1.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T16.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T16.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T16.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T16.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T2.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T4.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T8.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T8.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T16.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T16.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T16.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T16.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T2.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T32.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T32.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T32.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T32.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T4.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T8.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T8.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   }
 }

--- a/data/xsections_2017.json
+++ b/data/xsections_2017.json
@@ -2,9551 +2,11461 @@
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1127.0
+    "xsec": 1127.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23590000.0
+    "xsec": 23590000.0,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 109.8
+    "xsec": 109.8,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.98
+    "xsec": 21.98,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1555000.0
+    "xsec": 1555000.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 324500.0
+    "xsec": 324500.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30310.0
+    "xsec": 30310.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 187300000.0
+    "xsec": 187300000.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6444.0
+    "xsec": 6444.0,
+    "signal": 0
   },
   "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 7.465
+    "xsec": 7.465,
+    "signal": 0
   },
   "QCD_Pt_120to170_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 407700.0
+    "xsec": 407700.0,
+    "signal": 0
   },
   "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.6487
+    "xsec": 0.6487,
+    "signal": 0
   },
   "QCD_Pt_15to30_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1244000000.0
+    "xsec": 1244000000.0,
+    "signal": 0
   },
   "QCD_Pt_170to300_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 103700.0
+    "xsec": 103700.0,
+    "signal": 0
   },
   "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.08734
+    "xsec": 0.08734,
+    "signal": 0
   },
   "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.005237
+    "xsec": 0.005237,
+    "signal": 0
   },
   "QCD_Pt_300to470_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6826.0
+    "xsec": 6826.0,
+    "signal": 0
   },
   "QCD_Pt_30to50_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 106500000.0
+    "xsec": 106500000.0,
+    "signal": 0
   },
   "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.0001352
+    "xsec": 0.0001352,
+    "signal": 0
   },
   "QCD_Pt_470to600_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 551.2
+    "xsec": 551.2,
+    "signal": 0
   },
   "QCD_Pt_50to80_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 15700000.0
+    "xsec": 15700000.0,
+    "signal": 0
   },
   "QCD_Pt_600to800_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 156.7
+    "xsec": 156.7,
+    "signal": 0
   },
   "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 26.25
+    "xsec": 26.25,
+    "signal": 0
   },
   "QCD_Pt_80to120_TuneCP5_13TeV_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 2346000.0
+    "xsec": 2346000.0,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1092.0
+    "xsec": 1092.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23590000.0
+    "xsec": 23590000.0,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 99.76
+    "xsec": 99.76,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 20.35
+    "xsec": 20.35,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1551000.0
+    "xsec": 1551000.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323400.0
+    "xsec": 323400.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30140.0
+    "xsec": 30140.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 185300000.0
+    "xsec": 185300000.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6344.0
+    "xsec": 6344.0,
+    "signal": 0
   },
   "TTJets_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM":{
-    "xsec": 1.402,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 1.402,
+    "signal": 0
   },
   "TTJets_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM":{
-    "xsec": 0.5581,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.5581,
+    "signal": 0
   },
   "TTJets_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM":{
-    "xsec": 0.09876,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.09876,
+    "signal": 0
   },
   "TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM":{
-    "xsec": 0.001124,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.001124,
+    "signal": 0
   },
   "TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM":{
-    "xsec": 734.6,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 734.6,
+    "signal": 0
   },
   "DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 6529.0
+    "xsec": 6529.0,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-0To50_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1485.0
+    "xsec": 1485.0,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-50To100_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 397.4
+    "xsec": 397.4,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 97.2
+    "xsec": 97.2,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.701
+    "xsec": 3.701,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-400To650_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v4+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.5086
+    "xsec": 0.5086,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-650ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.04728
+    "xsec": 0.04728,
+    "signal": 0
   },
   "WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 0.98753,
     "br": 1,
-    "xsec": 66680.0
+    "xsec": 66680.0,
+    "signal": 0
   },
   "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 88.29
+    "xsec": 88.29,
+    "signal": 0
   },
   "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 365.34
+    "xsec": 365.34,
+    "signal": 0
   },
   "ST_tW_Dilept_5f_DR_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.289
+    "xsec": 3.289,
+    "signal": 0
   },
   "WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 11.09
+    "xsec": 11.09,
+    "signal": 0
   },
   "WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 4.664
+    "xsec": 4.664,
+    "signal": 0
   },
   "WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 6.565
+    "xsec": 6.565,
+    "signal": 0
   },
   "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.9738
+    "xsec": 0.9738,
+    "signal": 0
   },
   "ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.676
+    "xsec": 3.676,
+    "signal": 0
   },
   "ZZTo4L_TuneCP5_13TeV_powheg_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1.325
+    "xsec": 1.325,
+    "signal": 0
   },
   "ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 51.53
+    "xsec": 51.53,
+    "signal": 0
   },
   "WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 411.2
+    "xsec": 411.2,
+    "signal": 0
   },
   "TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.2163
+    "xsec": 0.2163,
+    "signal": 0
   },
   "TTWJetsToQQ_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.4432
+    "xsec": 0.4432,
+    "signal": 0
   },
   "TTZToQQ_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.5113
+    "xsec": 0.5113,
+    "signal": 0
   },
   "TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.2439
+    "xsec": 0.2439,
+    "signal": 0
   },
   "DYJetsToLL_M-10to50_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 20490.0
+    "xsec": 20490.0,
+    "signal": 0
   },
   "DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 15910.0
+    "xsec": 15910.0,
+    "signal": 0
   },
   "WJetsToLNu_Pt-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 733.1
+    "xsec": 733.1,
+    "signal": 0
   },
   "WJetsToLNu_Pt-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 27.92
+    "xsec": 27.92,
+    "signal": 0
   },
   "WJetsToLNu_Pt-400To600_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.547
+    "xsec": 3.547,
+    "signal": 0
   },
   "WJetsToLNu_Pt-600ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.5371
+    "xsec": 0.5371,
+    "signal": 0
   },
   "WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1244.0
+    "xsec": 1244.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1.152
+    "xsec": 1.152,
+    "signal": 0
   },
   "WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 337.8
+    "xsec": 337.8,
+    "signal": 0
   },
   "WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.02646
+    "xsec": 0.02646,
+    "signal": 0
   },
   "WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 44.93
+    "xsec": 44.93,
+    "signal": 0
   },
   "WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9_ext1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 44.93
+    "xsec": 44.93,
+    "signal": 0
   },
   "WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 11.19
+    "xsec": 11.19,
+    "signal": 0
   },
   "WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9_ext1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 11.19
+    "xsec": 11.19,
+    "signal": 0
   },
   "WJetsToLNu_HT-70To100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 1283.0
+    "xsec": 1283.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 4.926
+    "xsec": 4.926,
+    "signal": 0
   },
   "WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 51.65
+    "xsec": 51.65,
+    "signal": 0
   },
   "WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 9.119
+    "xsec": 9.119,
+    "signal": 0
   },
   "WZTo1L3Nu_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.414
+    "xsec": 3.414,
+    "signal": 0
   },
   "WplusH_HToBB_WToLNu_M-125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.2832
+    "xsec": 0.2832,
+    "signal": 0
   },
   "WminusH_HToBB_WToLNu_M-125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.177
+    "xsec": 0.177,
+    "signal": 0
   },
   "ttHToNonbb_M125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.5638
+    "xsec": 0.5638,
+    "signal": 0
   },
   "ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 0.5269
+    "xsec": 0.5269,
+    "signal": 0
   },
   "GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-4cores5k_106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 8639.0
+    "xsec": 8639.0,
+    "signal": 0
   },
   "GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 2173.0
+    "xsec": 2173.0,
+    "signal": 0
   },
   "GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 260.7
+    "xsec": 260.7,
+    "signal": 0
   },
   "GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 18650.0
+    "xsec": 18650.0,
+    "signal": 0
   },
   "GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 86.55
+    "xsec": 86.55,
+    "signal": 0
   },
   "ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 67.93
+    "xsec": 67.93,
+    "signal": 0
   },
   "ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 32.51
+    "xsec": 32.51,
+    "signal": 0
   },
   "ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 32.45
+    "xsec": 32.45,
+    "signal": 0
   },
   "ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 113.4
+    "xsec": 113.4,
+    "signal": 0
   },
   "VHToNonbb_M125_TuneCP5_13TeV-amcatnloFXFX_madspin_pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.935	
+    "xsec": 0.935	,
+    "signal": 0
   },
   "GluGluToSUEP_HT1000_T0p25_mS125.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS300.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS400.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS600.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS700.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS800.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS900.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS125.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS300.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS400.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS600.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS700.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS800.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS900.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS125.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS300.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS400.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS600.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS700.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS800.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS900.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS125.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS300.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS400.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS600.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS700.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS800.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS900.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS125.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS300.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS400.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS600.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS700.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS800.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS900.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS125.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS300.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS400.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS600.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS700.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS800.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS900.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS125.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS300.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS400.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS600.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS700.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS800.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS900.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS1000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS125.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS300.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS400.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS600.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS700.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS800.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS900.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS1000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS125.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS300.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS400.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS600.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS700.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS800.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS900.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS1000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS125.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS300.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS400.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS600.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS700.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS800.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS900.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS1000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS125.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS300.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS400.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS600.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS700.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS800.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS900.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS1000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS125.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS300.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS400.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS600.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS700.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS800.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS900.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS1000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
     "GluGluToSUEP_HT1000_T0p25_mS2000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
-  },
+    "xsec": 0.0096,
+    "signal": 1},
+
   "GluGluToSUEP_HT1000_T0p35_mS2000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS2000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS2000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS2000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS2000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+      "signal": 1 
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_generic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T0.35_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T0.70_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T1.40_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T2.80_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T5.60_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T0.25_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
+      "xsec": 1.358,
+      "signal": 1  
   },
   "ttHpythia_generic_M125.0_MD2.00_T0.50_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T1.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T8.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T0.75_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T12.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T1.50_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T3.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T6.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T1.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T16.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T8.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T16.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T8.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T0.35_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T0.70_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T1.40_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T2.80_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T5.60_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T0.50_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T1.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T8.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T0.75_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T12.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T1.50_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T3.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T6.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T1.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T16.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T8.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T16.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T8.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T0.25_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T0.50_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T1.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T0.50_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T1.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T8.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T0.75_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T12.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T1.50_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T3.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T6.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T1.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T16.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T8.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T16.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T2.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T4.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T8.00_HT-1_UL17_NANOAOD": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T0.250_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T0.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T0.350_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T0.700_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T1.400_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T2.800_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T5.600_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T0.500_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T0.500_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T0.500_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T0.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T1.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T1.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T1.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T2.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T4.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T8.000_modegeneric ": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi2.000_T8.000_modehadronic": {
+  "SUEP_mS125.000_mPhi2.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T0.750_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T0.750_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T0.750_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T0.750_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T1.500_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T1.500_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T1.500_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T1.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T12.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T12.000_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T12.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T12.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T3.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T3.000_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T3.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T3.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T6.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi3.000_T6.000_modehadronic": {
+  "SUEP_mS125.000_mPhi3.000_T6.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T6.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T1.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T1.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T1.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T16.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T16.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T16.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T16.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T2.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T4.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T8.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi4.000_T8.000_modehadronic": {
+  "SUEP_mS125.000_mPhi4.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T16.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T16.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T16.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T16.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T2.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T32.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T32.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T32.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T32.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T4.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T8.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
-  "SUEP_mS125.,000_mPhi8.000_T8.000_modehadronic": {
+  "SUEP_mS125.000_mPhi8.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   }
 }

--- a/data/xsections_2018.json
+++ b/data/xsections_2018.json
@@ -2,9661 +2,11593 @@
   "QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1127.0
+    "xsec": 1127.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23590000.0
+    "xsec": 23590000.0,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 109.8
+    "xsec": 109.8,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 21.98
+    "xsec": 21.98,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1555000.0
+    "xsec": 1555000.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 324500.0
+    "xsec": 324500.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30310.0
+    "xsec": 30310.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM":{
     "br": 1,
     "kr": 1,
-    "xsec": 6444.0
+    "xsec": 6444.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_PSWeights_13TeV-madgraph-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 187300000.0
+    "xsec": 187300000.0,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1064
+    "xsec": 1064,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 27990000
+    "xsec": 27990000,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 121.5
+    "xsec": 121.5,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 25.42
+    "xsec": 25.42,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1735000
+    "xsec": 1735000,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 366800
+    "xsec": 366800,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 29370
+    "xsec": 29370,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6524
+    "xsec": 6524,
+    "signal": 0
   },
   "QCD_Pt_80to120_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 2346000.0
+    "xsec": 2346000.0,
+    "signal": 0
   },
   "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 26.25
+    "xsec": 26.25,
+    "signal": 0
   },
   "QCD_Pt_600to800_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 156.7
+    "xsec": 156.7,
+    "signal": 0
   },
   "QCD_Pt_50to80_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 15700000.0
+    "xsec": 15700000.0,
+    "signal": 0
   },
   "QCD_Pt_470to600_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 551.2
+    "xsec": 551.2,
+    "signal": 0
   },
   "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-pilot_106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.0001352
+    "xsec": 0.0001352,
+    "signal": 0
   },
   "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.0001352
+    "xsec": 0.0001352,
+    "signal": 0
   },
   "QCD_Pt_30to50_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 106500000.0
+    "xsec": 106500000.0,
+    "signal": 0
   },
   "QCD_Pt_300to470_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6826.0
+    "xsec": 6826.0,
+    "signal": 0
   },
   "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.005237
+    "xsec": 0.005237,
+    "signal": 0
   },
   "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.08734
+    "xsec": 0.08734,
+    "signal": 0
   },
   "QCD_Pt_170to300_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 103700.0
+    "xsec": 103700.0,
+    "signal": 0
   },
   "QCD_Pt_15to30_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1244000000.0
+    "xsec": 1244000000.0,
+    "signal": 0
   },
   "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.6487
+    "xsec": 0.6487,
+    "signal": 0
   },
   "QCD_Pt_120to170_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 407700.0
+    "xsec": 407700.0,
+    "signal": 0
   },
   "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 7.465
+    "xsec": 7.465,
+    "signal": 0
   },
   "SUEP-m400-darkPhoHad+RunIIAutumn18-private+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1
+    "xsec": 1,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1735000
+    "xsec": 1735000,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 366800
+    "xsec": 366800,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 29370
+    "xsec": 29370,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6524
+    "xsec": 6524,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1064
+    "xsec": 1064,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 121.5
+    "xsec": 121.5,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 25.42
+    "xsec": 25.42,
+    "signal": 0
   },
   "QCD_HT1000to1500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1092.0
+    "xsec": 1092.0,
+    "signal": 0
   },
   "QCD_HT100to200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 23590000.0
+    "xsec": 23590000.0,
+    "signal": 0
   },
   "QCD_HT1500to2000_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 99.76
+    "xsec": 99.76,
+    "signal": 0
   },
   "QCD_HT2000toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 20.35
+    "xsec": 20.35,
+    "signal": 0
   },
   "QCD_HT200to300_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1551000.0
+    "xsec": 1551000.0,
+    "signal": 0
   },
   "QCD_HT300to500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 323400.0
+    "xsec": 323400.0,
+    "signal": 0
   },
   "QCD_HT500to700_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 30140.0
+    "xsec": 30140.0,
+    "signal": 0
   },
   "QCD_HT50to100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 185300000.0
+    "xsec": 185300000.0,
+    "signal": 0
   },
   "QCD_HT700to1000_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v2+AODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6344.0
+    "xsec": 6344.0,
+    "signal": 0
   },
    "TTJets_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "xsec": 0.09876,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "signal": 0
   },
   "TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
-    "xsec": 0.001124,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.001124,
+    "signal": 0
   },
   "TTJets_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
-    "xsec": 1.402,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 1.402,
+    "signal": 0
   },
   "TTJets_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
-    "xsec": 0.5581,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 0.5581,
+    "signal": 0
   },
   "TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
-    "xsec": 831.76,
     "br": 1,
-    "kr": 1
+    "kr": 1,
+    "xsec": 831.76,
+    "signal": 0
   },
   "DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6435.0
+    "xsec": 6435.0,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-0To50_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1485.0
+    "xsec": 1485.0,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 97.2
+    "xsec": 97.2,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.701
+    "xsec": 3.701,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-400To650_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5086
+    "xsec": 0.5086,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-50To100_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 397.4
+    "xsec": 397.4,
+    "signal": 0
   },
   "DYJetsToLL_LHEFilterPtZ-650ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.04728
+    "xsec": 0.04728,
+    "signal": 0
   },
   "DYJetsToLL_M-10to50_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 20490.0
+    "xsec": 20490.0,
+    "signal": 0
   },
   "DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 15910.0
+    "xsec": 15910.0,
+    "signal": 0
   },
   "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 88.29
+    "xsec": 88.29,
+    "signal": 0
   },
   "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 365.34
+    "xsec": 365.34,
+    "signal": 0
   },
   "ST_tW_Dilept_5f_DR_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.289
+    "xsec": 3.289,
+    "signal": 0
   },
   "WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 0.98753,
-    "xsec": 66680.0
+    "xsec": 66680.0,
+    "signal": 0
   },
   "WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 11.09
+    "xsec": 11.09,
+    "signal": 0
   },
   "WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 4.664
+    "xsec": 4.664,
+    "signal": 0
   },
   "WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 6.565
+    "xsec": 6.565,
+    "signal": 0
   },
   "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.9738
+    "xsec": 0.9738,
+    "signal": 0
   },
   "ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.676
+    "xsec": 3.676,
+    "signal": 0
   },
   "ZZTo4L_TuneCP5_13TeV_powheg_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1.325
+    "xsec": 1.325,
+    "signal": 0
   },
   "ZZZ_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1_ext1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.01398	
+    "xsec": 0.01398	,
+    "signal": 0
   },
   "WWZ_4F_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1_ext1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.1651
+    "xsec": 0.1651,
+    "signal": 0
   },
   "ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 51.53
+    "xsec": 51.53,
+    "signal": 0
   },
   "WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 411.2
+    "xsec": 411.2,
+    "signal": 0
   },
   "TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.2163
+    "xsec": 0.2163,
+    "signal": 0
   },
   "TTWJetsToQQ_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.4432
+    "xsec": 0.4432,
+    "signal": 0
   },
   "TTZToQQ_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5113
+    "xsec": 0.5113,
+    "signal": 0
   },
   "TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.2439
+    "xsec": 0.2439,
+    "signal": 0
   },
   "ttZJets_TuneCP5_13TeV_madgraphMLM_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5407
+    "xsec": 0.5407,
+    "signal": 0
   },
   "WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1244.0
+    "xsec": 1244.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1.152
+    "xsec": 1.152,
+    "signal": 0
   },
   "WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1_ext1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1.152
+    "xsec": 1.152,
+    "signal": 0
   },
   "WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 337.8
+    "xsec": 337.8,
+    "signal": 0
   },
   "WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.02646
+    "xsec": 0.02646,
+    "signal": 0
   },
   "WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 44.93
+    "xsec": 44.93,
+    "signal": 0
   },
   "WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1_ext1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 44.93
+    "xsec": 44.93,
+    "signal": 0
   },
   "WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 11.19
+    "xsec": 11.19,
+    "signal": 0
   },
   "WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1_ext1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 11.19
+    "xsec": 11.19,
+    "signal": 0
   },
   "WJetsToLNu_HT-70To100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 1283.0
+    "xsec": 1283.0,
+    "signal": 0
   },
   "WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 4.926
+    "xsec": 4.926,
+    "signal": 0
   },
   "WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1_ext1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 4.926
+    "xsec": 4.926,
+    "signal": 0
   },
   "WJetsToLNu_Pt-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 733.1
+    "xsec": 733.1,
+    "signal": 0
   },
   "WJetsToLNu_Pt-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 27.92
+    "xsec": 27.92,
+    "signal": 0
   },
   "WJetsToLNu_Pt-400To600_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.547
+    "xsec": 3.547,
+    "signal": 0
   },
   "WJetsToLNu_Pt-600ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5371
+    "xsec": 0.5371,
+    "signal": 0
   },
   "WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 51.65
+    "xsec": 51.65,
+    "signal": 0
   },
   "WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 9.119
+    "xsec": 9.119,
+    "signal": 0
   },
   "WZTo1L3Nu_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v3+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 3.414
+    "xsec": 3.414,
+    "signal": 0
   },
   "WplusH_HToBB_WToLNu_M-125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.2832
+    "xsec": 0.2832,
+    "signal": 0
   },
   "WminusH_HToBB_WToLNu_M-125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.177
+    "xsec": 0.177,
+    "signal": 0
   },
   "ttHToNonbb_M125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5638
+    "xsec": 0.5638,
+    "signal": 0
   },
   "ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.5269
+    "xsec": 0.5269,
+    "signal": 0
   },
   "GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-4cores5k_106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 8639.0
+    "xsec": 8639.0,
+    "signal": 0
   },
   "GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 2173.0
+    "xsec": 2173.0,
+    "signal": 0
   },
   "GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 260.7
+    "xsec": 260.7,
+    "signal": 0
   },
   "GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 18650.0
+    "xsec": 18650.0,
+    "signal": 0
   },
   "GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 86.55
+    "xsec": 86.55,
+    "signal": 0
   },
   "ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "kr": 1,
     "br": 1,
-    "xsec": 3.74
+    "xsec": 3.74,
+    "signal": 0
   },
   "ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 67.93
+    "xsec": 67.93,
+    "signal": 0
   },
   "ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 32.51
+    "xsec": 32.51,
+    "signal": 0
   },
   "ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 32.45
+    "xsec": 32.45,
+    "signal": 0
   },
   "ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 113.4
+    "xsec": 113.4,
+    "signal": 0
   },
   "VHToNonbb_M125_TuneCP5_13TeV-amcatnloFXFX_madspin_pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
     "kr": 1,
-    "xsec": 0.935	
+    "xsec": 0.935	,
+    "signal": 0
   },
   "GluGluToSUEP_HT1000_T0p25_mS125.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS300.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS400.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS600.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS700.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS800.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS900.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS125.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS300.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS400.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS600.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS700.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS800.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS900.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS125.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS300.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS400.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS600.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS700.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS800.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS900.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS125.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS300.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS400.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS600.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS700.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS800.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS900.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS125.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS300.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS400.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS600.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS700.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS800.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS900.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS125.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS300.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS400.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS600.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS700.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS800.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS900.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS125.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS300.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS400.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS600.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS700.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS800.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS900.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS125.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS300.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS400.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS600.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS700.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS800.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS900.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS125.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS300.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS400.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS600.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS700.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS800.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS900.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS125.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS300.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS400.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS600.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS700.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS800.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS900.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS125.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS300.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS400.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS600.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS700.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS800.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS900.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS125.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS300.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS400.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS600.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS700.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS800.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS900.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS125.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS300.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS400.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS600.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS700.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS800.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS900.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS125.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS300.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS400.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS600.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS700.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS800.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS900.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS125.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS300.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS400.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS600.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS700.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS800.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS900.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS125.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS300.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS400.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS600.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS700.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS800.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS900.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS125.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS300.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS400.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS600.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS700.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS800.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS900.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS125.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.00259608107509008,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0048232274473043275,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS300.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.009035833057989004,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS400.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.01466909822798684,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.021723022957297833,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS600.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.030197607245921985,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS700.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0400928510938593,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS800.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.051408754501109766,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS900.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.0641453174676734,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.07830253999355018,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS125.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS300.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS400.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS600.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS700.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS800.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS900.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p25_mS1000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS125.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS300.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS400.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS600.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS700.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS800.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS900.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p35_mS1000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS125.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS300.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS400.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS600.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS700.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS800.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS900.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p50_mS1000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS125.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS300.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS400.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS600.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS700.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS800.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS900.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p70_mS1000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS125.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS300.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS400.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS600.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS700.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS800.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS900.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T0p75_mS1000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS125.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS300.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS400.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS600.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS700.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS800.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS900.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p00_mS1000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS125.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS300.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS400.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS600.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS700.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS800.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS900.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p40_mS1000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS125.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS300.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS400.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS600.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS700.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS800.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS900.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T1p50_mS1000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS125.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS300.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS400.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS600.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS700.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS800.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS900.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p00_mS1000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS125.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS300.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS400.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS600.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS700.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS800.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS900.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T2p80_mS1000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS125.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS300.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS400.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS600.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS700.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS800.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS900.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T3p00_mS1000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS125.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS300.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS400.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS600.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS700.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS800.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS900.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T4p00_mS1000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS125.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS300.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS400.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS600.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS700.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS800.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS900.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T5p60_mS1000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS125.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS300.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS400.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS600.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS700.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS800.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS900.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T6p00_mS1000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS125.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS300.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS400.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS600.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS700.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS800.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS900.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T8p00_mS1000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS125.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS300.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS400.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS600.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS700.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS800.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS900.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T12p0_mS1000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS125.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS300.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS400.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS600.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS700.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS800.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS900.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T16p0_mS1000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS125.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.022561693317296093,
-    "xsec": 45.2
+    "xsec": 45.2,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.045499775471722015,
-    "xsec": 16.9
+    "xsec": 16.9,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS300.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.08115244345939307,
-    "xsec": 6.59
+    "xsec": 6.59,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS400.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.12259774967384872,
-    "xsec": 3.16
+    "xsec": 3.16,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.16983569411508892,
-    "xsec": 1.71
+    "xsec": 1.71,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS600.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.22286627678311371,
-    "xsec": 1.0
+    "xsec": 1.0,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS700.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.2816894976779231,
-    "xsec": 0.621
+    "xsec": 0.621,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS800.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.3463053567995171,
-    "xsec": 0.402
+    "xsec": 0.402,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS900.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4167138541478956,
-    "xsec": 0.269
+    "xsec": 0.269,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
   "GluGluToSUEP_HT400_T32p0_mS1000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.4929149897230587,
-    "xsec": 0.185
+    "xsec": 0.185,
+    "signal": 1
   },
     "GluGluToSUEP_HT1000_T0p25_mS2000.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
-  },
+    "xsec": 0.0096,
+    "signal": 1},
+
   "GluGluToSUEP_HT1000_T0p35_mS2000.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS2000.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS2000.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS2000.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS2000.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS2000.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS2000.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS2000.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS2000.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS2000.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS2000.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS2000.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS2000.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS2000.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS2000.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS2000.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS2000.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 1.00000,
-    "xsec": 0.0096
+    "xsec": 0.0096,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1200.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1200.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1200.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1200.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1200.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1200.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1200.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1200.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1200.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1200.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1200.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1200.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1200.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1200.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1200.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1200.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1200.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1200.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.19190,
-    "xsec": 0.0926
+    "xsec": 0.0926,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p25_mS1500.000_mPhi1.000_T0.250_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p35_mS1500.000_mPhi1.400_T0.350_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi1.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p50_mS1500.000_mPhi2.000_T0.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p70_mS1500.000_mPhi1.400_T0.700_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T0p75_mS1500.000_mPhi3.000_T0.750_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi1.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi2.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p00_mS1500.000_mPhi4.000_T1.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p40_mS1500.000_mPhi1.400_T1.400_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T1p50_mS1500.000_mPhi3.000_T1.500_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi1.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi2.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi4.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p00_mS1500.000_mPhi8.000_T2.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T2p80_mS1500.000_mPhi1.400_T2.800_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T3p00_mS1500.000_mPhi3.000_T3.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi1.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi2.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi4.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T4p00_mS1500.000_mPhi8.000_T4.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T5p60_mS1500.000_mPhi1.400_T5.600_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T6p00_mS1500.000_mPhi3.000_T6.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi2.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi4.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T8p00_mS1500.000_mPhi8.000_T8.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T12p0_mS1500.000_mPhi3.000_T12.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi4.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T16p0_mS1500.000_mPhi8.000_T16.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modegeneric_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modeleptonic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "GluGluToSUEP_HT1000_T32p0_mS1500.000_mPhi8.000_T32.000_modehadronic_TuneCP5_13TeV-pythia8": {
     "br": 1,
     "kr": 0.58560,
-    "xsec": 0.0369
+    "xsec": 0.0369,
+    "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "WHleptonicpythia_generic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_generic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T0.35_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T0.70_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T1.40_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T2.80_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD1.40_T5.60_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_hadronic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T0.25_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD1.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T32.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "WHleptonicpythia_leptonic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD": {
       "br": 0.3177,
       "kr": 1,
-      "xsec": 1.358
-  },
+      "xsec": 1.358,
+    "signal": 1
+    },
   "ttHpythia_generic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_generic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T0.35_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T0.70_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T1.40_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T2.80_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD1.40_T5.60_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_hadronic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T0.25_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T0.50_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T1.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD1.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T0.50_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T1.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD2.00_T8.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T0.75_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T12.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T1.50_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T3.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD3.00_T6.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T1.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T16.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD4.00_T8.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T16.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T2.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T4.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "ttHpythia_leptonic_M125.0_MD8.00_T8.00_HT-1_UL18_NANOAOD":{
     "br": 1,
     "kr": 1,
-    "xsec": 0.4987
+    "xsec": 0.4987,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T0.250_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T0.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T0.350_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T0.700_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T1.400_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T2.800_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi1.400_T5.600_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T0.500_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi2.000_T0.500_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T0.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T1.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi2.000_T1.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi2.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi2.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T8.000_modegeneric ": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi2.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi2.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T0.750_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi3.000_T0.750_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T0.750_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T1.500_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi3.000_T1.500_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T1.500_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T12.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi3.000_T12.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T12.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T3.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi3.000_T3.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T3.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T6.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi3.000_T6.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi3.000_T6.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T1.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi4.000_T1.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T1.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T16.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi4.000_T16.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T16.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi4.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi4.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T8.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi4.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi4.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T16.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi8.000_T16.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T16.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T2.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi8.000_T2.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T2.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T32.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi8.000_T32.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T32.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T4.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi8.000_T4.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T4.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T8.000_modegeneric": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.,000_mPhi8.000_T8.000_modehadronic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   },
   "SUEP_mS125.000_mPhi8.000_T8.000_modeleptonic": {
     "br": 0.3177,
     "kr": 1,
-    "xsec": 1.358
+    "xsec": 1.358,
+    "signal": 1
   }
 }

--- a/histmaker/fill_utils.py
+++ b/histmaker/fill_utils.py
@@ -75,6 +75,16 @@ def get_git_info(path="."):
     return commit, diff
 
 
+def isSampleSignal(sample: str, year: str, path: str = "../data/") -> bool:
+    """
+    Check the xsections json database to see if a sample is signal or not.
+    """
+    xsecs_database = f"{path}/xsections_{year}.json"
+    with open(xsecs_database) as file:
+        MC_xsecs = json.load(file)
+        return bool(MC_xsecs[sample]["signal"])
+
+
 def getXSection(
     dataset: str, year, path: str = "../data/", failOnKeyError: bool = True
 ) -> float:

--- a/histmaker/make_hists.py
+++ b/histmaker/make_hists.py
@@ -31,8 +31,7 @@ from CMS_corrections import (
     track_killing,
     triggerSF,
 )
-
-import plotting.plot_utils
+import plotting.plot_utils as plot_utils
 
 
 ### Parser #######################################################################################################
@@ -106,9 +105,6 @@ def makeParser(parser=None):
         type=int,
         default=0,
         help="Run systematic up and down variations in additional to the nominal.",
-    )
-    parser.add_argument(
-        "--predictSR", type=int, default=0, help="Predict SR using ABCD method."
     )
     parser.add_argument(
         "--blind", type=int, default=1, help="Blind the data (default=True)"
@@ -612,6 +608,8 @@ def main():
     nfailed = 0
     ntotal = 0
     total_gensumweight = 0
+    xsection = 1
+    lumi = 1
     output = {"labels": []}
     cutflow = {}
 
@@ -797,51 +795,26 @@ def main():
                 out_label="GNN",
             )
 
-    # apply xsec and gensumweight (but no xsec to SUEP signal samples)
-    xsection = 1
+    # store whether sample is signal
+    isSignal = (options.isMC) and (fill_utils.isSampleSignal(sample, options.era))
+    logging.debug("Is signal: " + str(isSignal))
+
+    # apply normalization to samples
     if options.isMC:
-        logging.info("Applying normalization.")
-        if "SUEP" not in sample:
-            xsection = fill_utils.getXSection(sample, options.era, failOnKeyError=True)
-            logging.debug(f"Applying cross section {xsection}.")
-        logging.debug(f"Applying total_gensumweight {total_gensumweight}.")
-        output = fill_utils.apply_normalization(output, xsection / total_gensumweight)
-        cutflow = fill_utils.apply_normalization(cutflow, xsection / total_gensumweight)
+        logging.debug(f"Found total_gensumweight {total_gensumweight}.")
+        xsection = fill_utils.getXSection(sample, options.era, failOnKeyError=True)
+        logging.debug(f"Found cross section x kr x br: {xsection}.")
+        lumi = plot_utils.getLumi(options.era, options.scouting)
+        logging.debug(f"Found lumi: {lumi}.")
 
-    # Make ABCD expected histogram for signal region
-    if options.doABCD and options.predictSR:
-        logging.info("Predicting SR using ABCD method.")
+        if isSignal:  
+            normalization = 1 / total_gensumweight
+        else:
+            normalization = xsection * lumi / total_gensumweight
 
-        # Loop through every configuration
-        for label_out, config_out in config.items():
-            xregions = np.array(config_out["xvar_regions"]) * 1.0j
-            yregions = np.array(config_out["yvar_regions"]) * 1.0j
-            xvar = config_out["xvar"].replace("_" + config_out["input_method"], "")
-            yvar = config_out["yvar"].replace("_" + config_out["input_method"], "")
-            hist_name = f"2D_{xvar}_vs_{yvar}_{label_out}"
-
-            # Check if histogram exists
-            if hist_name not in output.keys():
-                logging.warning(f"{hist_name} has not been created.")
-                continue
-
-            # Only calculate predicted for 9 region ABCD for now, should be made flexible based on the number of regions defined in the config
-            if (len(xregions) != 4) or (len(yregions) != 4):
-                logging.warning(
-                    f"Can only calculate SR for 9 region ABCD, skipping {label_out}"
-                )
-                continue
-
-            try:
-                # Calculate expected SR from ABCD method
-                # sum_var = 'x' corresponds to scaling F histogram
-                _, SR_exp = plot_utils.ABCD_9regions_errorProp(
-                    output[hist_name], xregions, yregions, sum_var="x"
-                )
-                output[f"I_{yvar}_{label_out}_exp"] = SR_exp
-            except ZeroDivisionError:
-                logging.warning(f"ZeroDivisionError for {label_out}, skipping.")
-                continue
+        logging.info(f"Applying normalization: {normalization}.")
+        output = fill_utils.apply_normalization(output, normalization)
+        cutflow = fill_utils.apply_normalization(cutflow, normalization)
 
     # form metadata
     metadata = {
@@ -849,10 +822,12 @@ def main():
         "analysis": options.channel,
         "scouting": int(options.scouting),
         "isMC": int(options.isMC),
+        "signal": int(isSignal),
         "era": options.era,
         "sample": sample,
-        "xsec": xsection,
+        "xsec": float(xsection),
         "gensumweight": int(total_gensumweight),
+        "lumi": float(lumi),
         "nfiles": ntotal,
         "nfailed": nfailed,
     }

--- a/histmaker/make_hists.py
+++ b/histmaker/make_hists.py
@@ -31,6 +31,7 @@ from CMS_corrections import (
     track_killing,
     triggerSF,
 )
+
 import plotting.plot_utils as plot_utils
 
 
@@ -807,7 +808,7 @@ def main():
         lumi = plot_utils.getLumi(options.era, options.scouting)
         logging.debug(f"Found lumi: {lumi}.")
 
-        if isSignal:  
+        if isSignal:
             normalization = 1 / total_gensumweight
         else:
             normalization = xsection * lumi / total_gensumweight

--- a/plotting/plot_utils.py
+++ b/plotting/plot_utils.py
@@ -471,8 +471,8 @@ def getLumi(era: str, scouting: bool) -> float:
 
 
 def loader(
-    infile_names, 
-    year=None,       # once everyone starts making histograms with metadata, these can be dropped   
+    infile_names,
+    year=None,  # once everyone starts making histograms with metadata, these can be dropped
     auto_lumi=True,  # once everyone starts making histograms with metadata, these can be dropped
     scouting=False,  # once everyone starts making histograms with metadata, these can be dropped
     by_bin=False,
@@ -512,18 +512,22 @@ def loader(
         norm = 1
 
         # finds era
-        if file_metadata and ("era" in file_metadata.keys()) and ("lumi" in file_metadata.keys()):
+        if (
+            file_metadata
+            and ("era" in file_metadata.keys())
+            and ("lumi" in file_metadata.keys())
+        ):
             era = file_metadata["era"]
             lumi = float(file_metadata["lumi"])
         else:
             # for older histograms, we need to scale by lumi, and find era via the filename
             # once everyone starts making histograms with metadata, this can be dropped
-            lumi, era = findLumiAndEra(
-                year, auto_lumi, infile_name, scouting
-            )  
+            lumi, era = findLumiAndEra(year, auto_lumi, infile_name, scouting)
             norm *= lumi
-            if verbose: print("Applying lumi", lumi)
-        if verbose: print("Found era", era)
+            if verbose:
+                print("Applying lumi", lumi)
+        if verbose:
+            print("Found era", era)
 
         # get the normalization factor for SUEP samples
         # xsec is already apply in make_hists.py for non SUEP samples
@@ -533,12 +537,10 @@ def loader(
                 if verbose:
                     print("Applying xsec", xsec)
                     print("Applying lumi", lumi)
-                norm *= xsec*lumi
+                norm *= xsec * lumi
         elif "SUEP" in infile_name.split("/")[-1]:
             # for older histograms, we didn't have metadata, so we need to find xsec via string manipulation
-            sample_name = (
-                infile_name.split("/")[-1].split("13TeV")[0] + "13TeV-pythia8"
-            )
+            sample_name = infile_name.split("/")[-1].split("13TeV")[0] + "13TeV-pythia8"
             xsec = fill_utils.getXSection(sample_name, year=era)
             if verbose:
                 print("Applying xsec", xsec)

--- a/plotting/plot_utils.py
+++ b/plotting/plot_utils.py
@@ -471,14 +471,14 @@ def getLumi(era: str, scouting: bool) -> float:
 
 
 def loader(
-    infile_names,
-    year=None,
+    infile_names, 
+    year=None,       # once everyone starts making histograms with metadata, these can be dropped   
     auto_lumi=True,  # once everyone starts making histograms with metadata, these can be dropped
     scouting=False,  # once everyone starts making histograms with metadata, these can be dropped
     by_bin=False,
     by_year=False,
-    xsec_SUEP=True,
     load_cutflows=False,
+    only_cutflows=False,
     verbose=False,
 ):
     """
@@ -491,8 +491,8 @@ def loader(
     - scouting (bool, optional): Flag to indicate whether the data is from scouting, used for the lumi. Default is False.
     - by_bin (bool, optional): Flag to group histograms by bin. Default is False.
     - by_year (bool, optional): Flag to group histograms by year. Default is True.
-    - xsec_SUEP (bool, optional): Flag to apply the cross-section normalization factor for SUEP samples. Default is True.
-    - cutflows (bool, optional): Flag to load cutflows instead of histograms. Default is False.
+    - load_cutflows (bool, optional): Flag to load cutflows along side histograms. Default is False.
+    - only_cutflows (bool, optional): Flag to load cutflows instead of histograms. Default is False.
 
     Returns:
     - output (dict): Dictionary containing the loaded histograms (or cutflows) grouped by sample, bin, and year.
@@ -511,40 +511,38 @@ def loader(
         file_hists, file_metadata = openHistFile(infile_name)
         norm = 1
 
-        # sets the lumi based on year
-        if file_metadata and (year is None) and ("isMC" in file_metadata.keys()):
-            if int(file_metadata["isMC"]):
-                lumi = getLumi(
-                    file_metadata["era"], bool(float(file_metadata["scouting"]))
-                )
-            else:
-                lumi = 1
+        # finds era
+        if file_metadata and ("era" in file_metadata.keys()) and ("lumi" in file_metadata.keys()):
             era = file_metadata["era"]
+            lumi = float(file_metadata["lumi"])
         else:
+            # for older histograms, we need to scale by lumi, and find era via the filename
+            # once everyone starts making histograms with metadata, this can be dropped
             lumi, era = findLumiAndEra(
                 year, auto_lumi, infile_name, scouting
-            )  # once everyone starts making histograms with metadata, this can be dropped
-        if verbose:
-            print("Using lumi", lumi, "and era", era)
-        norm *= lumi
+            )  
+            norm *= lumi
+            if verbose: print("Applying lumi", lumi)
+        if verbose: print("Found era", era)
 
         # get the normalization factor for SUEP samples
         # xsec is already apply in make_hists.py for non SUEP samples
-        if xsec_SUEP:
-            if "sample" in file_metadata.keys():
-                if "SUEP" in file_metadata["sample"]:
-                    xsec = fill_utils.getXSection(file_metadata["sample"], year=era)
-                    if verbose:
-                        print("Applying xsec", xsec)
-                    norm *= xsec
-            elif "SUEP" in infile_name.split("/")[-1]:
-                sample_name = (
-                    infile_name.split("/")[-1].split("13TeV")[0] + "13TeV-pythia8"
-                )
-                xsec = fill_utils.getXSection(sample_name, year=era)
+        if "signal" in file_metadata.keys():
+            if file_metadata["signal"]:
+                xsec = float(file_metadata["xsec"])
                 if verbose:
                     print("Applying xsec", xsec)
-                norm *= xsec
+                    print("Applying lumi", lumi)
+                norm *= xsec*lumi
+        elif "SUEP" in infile_name.split("/")[-1]:
+            # for older histograms, we didn't have metadata, so we need to find xsec via string manipulation
+            sample_name = (
+                infile_name.split("/")[-1].split("13TeV")[0] + "13TeV-pythia8"
+            )
+            xsec = fill_utils.getXSection(sample_name, year=era)
+            if verbose:
+                print("Applying xsec", xsec)
+            norm *= xsec
 
         # get the sample name and the bin name
         # e.g. for QCD_Pt_15to30_.. the sample is QCD_Pt and the bin is QCD_Pt_15to30
@@ -563,9 +561,9 @@ def loader(
                 samplesToAdd.append("_".join([bin, era]))
 
         for s in samplesToAdd:
-            if load_cutflows:
+            if only_cutflows or load_cutflows:
                 output = fillCutflows(file_metadata, s, output, norm)
-            else:
+            if not only_cutflows:
                 output = fillSample(file_hists, s, output, norm)
 
     return output


### PR DESCRIPTION
- added signal boolean in jsons
- lumi is now applied to non-signal MC in the histmaker, alongside the rest of normalizations
- histmaker checks the jsons file as to whether any given sample is a signal, instead of doing awkward string matching
- loader() now checks the metadata to decide if a sample is a signal or not, and applies lumi*xsec if it is
- removed `predictSR` flag from histmaker, it has been broken for a long time