### PR TITLE
2916apv btag utils bug fix in ntuple maker

### DIFF
--- a/workflows/SUEP_coffea_WH.py
+++ b/workflows/SUEP_coffea_WH.py
@@ -461,14 +461,20 @@ class SUEP_cluster_WH(processor.ProcessorABC):
             ).to_list()
 
         # saving number of bjets for different definitions (higher or lower requirements on b-likeliness) - see btag_utils.py
+        # btag function requests eras as integers (used again for btag weights)
+        if self.era == "2016apv":
+            era_int = 2015
+        else:
+            era_int = int(self.era)
+
         output["vars"]["nBLoose"] = ak.sum(
-            (self.jets_jec.btag >= btagcuts("Loose", int(self.era))), axis=1
+            (self.jets_jec.btag >= btagcuts("Loose", era_int)), axis=1
         )[:]
         output["vars"]["nBMedium"] = ak.sum(
-            (self.jets_jec.btag >= btagcuts("Medium", int(self.era))), axis=1
+            (self.jets_jec.btag >= btagcuts("Medium", era_int)), axis=1
         )[:]
         output["vars"]["nBTight"] = ak.sum(
-            (self.jets_jec.btag >= btagcuts("Tight", int(self.era))), axis=1
+            (self.jets_jec.btag >= btagcuts("Tight", era_int)), axis=1
         )[:]
 
         # saving kinematic variables for three leading pT jets
@@ -606,7 +612,7 @@ class SUEP_cluster_WH(processor.ProcessorABC):
                 output["vars"]["PSWeight"] = psweights
 
             bTagWeights = doBTagWeights(
-                events, self.jets_jec, int(self.era), "L", do_syst=self.do_syst
+                events, self.jets_jec, era_int, "L", do_syst=self.do_syst
             )  # Does not change selection
             output["vars"]["bTagWeight"] = bTagWeights["central"][:]  # BTag weights
 
@@ -686,13 +692,13 @@ class SUEP_cluster_WH(processor.ProcessorABC):
         ak4jets_noLepIso = WH_utils.getAK4Jets(jets_c, isMC=self.isMC)
         output["vars"]["ngood_ak4jets_noLepIso"] = ak.num(ak4jets_noLepIso).to_list()
         output["vars"]["nBLoose_noLepIso"] = ak.sum(
-            (ak4jets_noLepIso.btag >= btagcuts("Loose", int(self.era))), axis=1
+            (ak4jets_noLepIso.btag >= btagcuts("Loose", era_int)), axis=1
         )[:]
         output["vars"]["nBMedium_noLepIso"] = ak.sum(
-            (ak4jets_noLepIso.btag >= btagcuts("Medium", int(self.era))), axis=1
+            (ak4jets_noLepIso.btag >= btagcuts("Medium", era_int)), axis=1
         )[:]
         output["vars"]["nBTight_noLepIso"] = ak.sum(
-            (ak4jets_noLepIso.btag >= btagcuts("Tight", int(self.era))), axis=1
+            (ak4jets_noLepIso.btag >= btagcuts("Tight", era_int)), axis=1
         )[:]
 
         # W kinematics


### PR DESCRIPTION
- btag utils code accepts eras as ints (where 2016apv == 2015) - the rest of the codebase does not. to keep btag_utils unchanged, added quick workaround in the ntuple maker