### PR TITLE
JEC fixes

### DIFF
--- a/data/xsections_2016.json
+++ b/data/xsections_2016.json
@@ -475,7 +475,7 @@
   },
   "WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2+MINIAODSIM": {
     "br": 1,
-    "kr": 0.98753,
+    "kr": 1,
     "xsec": 67350.0,
     "signal": 0
   },

--- a/data/xsections_2016apv.json
+++ b/data/xsections_2016apv.json
@@ -474,7 +474,7 @@
     "signal": 0
   },
   "WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2+MINIAODSIM": {
-    "kr": 0.98753,
+    "kr": 1,
     "br": 1,
     "xsec": 67350.0,
     "signal": 0

--- a/data/xsections_2017.json
+++ b/data/xsections_2017.json
@@ -270,7 +270,7 @@
     "signal": 0
   },
   "WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
-    "kr": 0.98753,
+    "kr": 1,
     "br": 1,
     "xsec": 66680.0,
     "signal": 0

--- a/data/xsections_2018.json
+++ b/data/xsections_2018.json
@@ -403,7 +403,7 @@
   },
   "WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8+RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2+MINIAODSIM": {
     "br": 1,
-    "kr": 0.98753,
+    "kr": 1,
     "xsec": 66680.0,
     "signal": 0
   },

--- a/filelist/WH/list_2016_Data_WH.txt
+++ b/filelist/WH/list_2016_Data_WH.txt
@@ -1,6 +1,3 @@
-/store/user/paus/nanosu/A02/DoubleMuon+Run2016F-UL2016_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2016G-UL2016_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2016H-UL2016_MiniAODv2-v2+MINIAOD
 /store/user/paus/nanosu/A02/SingleElectron+Run2016F-UL2016_MiniAODv2-v2+MINIAOD
 /store/user/paus/nanosu/A02/SingleElectron+Run2016G-UL2016_MiniAODv2-v2+MINIAOD
 /store/user/paus/nanosu/A02/SingleElectron+Run2016H-UL2016_MiniAODv2-v2+MINIAOD

--- a/filelist/WH/list_2016apv_Data_WH.txt
+++ b/filelist/WH/list_2016apv_Data_WH.txt
@@ -1,7 +1,3 @@
-/store/user/paus/nanosu/A02/DoubleMuon+Run2016C-HIPM_UL2016_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2016D-HIPM_UL2016_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2016E-HIPM_UL2016_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2016F-HIPM_UL2016_MiniAODv2-v1+MINIAOD
 /store/user/paus/nanosu/A02/SingleElectron+Run2016B-ver1_HIPM_UL2016_MiniAODv2-v2+MINIAOD
 /store/user/paus/nanosu/A02/SingleElectron+Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2+MINIAOD
 /store/user/paus/nanosu/A02/SingleElectron+Run2016C-HIPM_UL2016_MiniAODv2-v2+MINIAOD

--- a/filelist/WH/list_2017_Data_WH.txt
+++ b/filelist/WH/list_2017_Data_WH.txt
@@ -1,8 +1,3 @@
-/store/user/paus/nanosu/A02/DoubleMuon+Run2017B-UL2017_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2017C-UL2017_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2017D-UL2017_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2017E-UL2017_MiniAODv2-v2+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2017F-UL2017_MiniAODv2-v1+MINIAOD
 /store/user/paus/nanosu/A02/SingleElectron+Run2017B-UL2017_MiniAODv2-v1+MINIAOD
 /store/user/paus/nanosu/A02/SingleElectron+Run2017C-UL2017_MiniAODv2-v1+MINIAOD
 /store/user/paus/nanosu/A02/SingleElectron+Run2017D-UL2017_MiniAODv2-v1+MINIAOD

--- a/filelist/WH/list_2018_Data_WH.txt
+++ b/filelist/WH/list_2018_Data_WH.txt
@@ -1,7 +1,3 @@
-/store/user/paus/nanosu/A02/DoubleMuon+Run2018A-UL2018_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2018B-UL2018_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2018C-UL2018_MiniAODv2-v1+MINIAOD
-/store/user/paus/nanosu/A02/DoubleMuon+Run2018D-UL2018_MiniAODv2-v1+MINIAOD
 /store/user/paus/nanosu/A02/EGamma+Run2018A-UL2018_MiniAODv2-v1+MINIAOD
 /store/user/paus/nanosu/A02/EGamma+Run2018B-UL2018_MiniAODv2-v1+MINIAOD
 /store/user/paus/nanosu/A02/EGamma+Run2018C-UL2018_MiniAODv2-v1+MINIAOD

--- a/workflows/CMS_corrections/jetmet_utils.py
+++ b/workflows/CMS_corrections/jetmet_utils.py
@@ -195,6 +195,7 @@ def prepareJetsForFactory(isMC, events, jets):
 
     return jets
 
+
 def prepareScoutingJetsForFactory(isMC: int, era: str, events, jets):
 
     jets["pt_raw"] = jets.pt
@@ -205,6 +206,7 @@ def prepareScoutingJetsForFactory(isMC: int, era: str, events, jets):
     jets["event_rho"] = events.rho
 
     return jets
+
 
 def prepareMETForFactory(MET):
 
@@ -345,16 +347,37 @@ def getCorrectedMET(sample, isMC, era, events):
 
     return met_factory.build(met, alljets_forMET, lazy_cache=jec_cache)
 
-def applyJECStoJets(sample, isMC, era, events, jets, jer: bool = False, scouting: bool = False, prefix: str = ""):
+
+def applyJECStoJets(
+    sample,
+    isMC,
+    era,
+    events,
+    jets,
+    jer: bool = False,
+    scouting: bool = False,
+    prefix: str = "",
+):
 
     jet_factory = getCorrectedJetsFactory(sample, isMC, era, jer=jer, prefix=prefix)
     jec_cache = cachetools.Cache(np.inf)
-    if scouting: jets = prepareScoutingJetsForFactory(isMC, era, events, jets)
-    else: jets = prepareJetsForFactory(isMC, events, jets)
+    if scouting:
+        jets = prepareScoutingJetsForFactory(isMC, era, events, jets)
+    else:
+        jets = prepareJetsForFactory(isMC, events, jets)
     jets_corrected = jet_factory.build(jets, lazy_cache=jec_cache)
     return jets_corrected
 
-def getJECCorrectedAK4Jets(sample, isMC, era, events, jer: bool = False, scouting: bool = False, prefix: str = ""):
+
+def getJECCorrectedAK4Jets(
+    sample,
+    isMC,
+    era,
+    events,
+    jer: bool = False,
+    scouting: bool = False,
+    prefix: str = "",
+):
 
     if scouting:
         if (isMC == 1) and (era == "2016"):
@@ -364,4 +387,6 @@ def getJECCorrectedAK4Jets(sample, isMC, era, events, jer: bool = False, scoutin
     else:
         jets = events.Jet
 
-    return applyJECStoJets(sample, isMC, era, events, jets, jer=jer, scouting=scouting, prefix=prefix)
+    return applyJECStoJets(
+        sample, isMC, era, events, jets, jer=jer, scouting=scouting, prefix=prefix
+    )

--- a/workflows/CMS_corrections/jetmet_utils.py
+++ b/workflows/CMS_corrections/jetmet_utils.py
@@ -159,9 +159,8 @@ def apply_jecs(self, Sample, events, prefix=""):
         jets["pt_raw"] = (1 - jets["rawFactor"]) * jets["pt"]
         jets["mass_raw"] = (1 - jets["rawFactor"]) * jets["mass"]
         if int(self.isMC):
-            jets["pt_gen"] = ak.values_astype(
-                ak.fill_none(jets.matched_gen.pt, 0), np.float32
-            )
+            jets["matched_gen_0p2"] = jets.nearest(events.GenJet, threshold=0.2)
+            jets["pt_gen"] = ak.values_astype(ak.fill_none(jets.matched_gen_0p2.pt, 0), np.float32)
         jets["event_rho"] = ak.broadcast_arrays(events.fixedGridRhoFastjetAll, jets.pt)[0]
     # Create the map (for both MC and data)
     name_map = jec_stack_ak4.blank_name_map

--- a/workflows/CMS_corrections/jetmet_utils.py
+++ b/workflows/CMS_corrections/jetmet_utils.py
@@ -142,13 +142,8 @@ def makeJECStack(Sample: str, isMC: int, era: str, jer: bool = False, prefix: st
 
 def getCorrectedJetsFactory(Sample, isMC, era, jer=False, prefix=""):
 
-<<<<<<< HEAD
     jec_stack_ak4 = makeJECStack(Sample, isMC, era, jer=jer, prefix=prefix)
-        
-=======
-    jec_stack_ak4 = makeJECStack(Sample, isMC, era, jer=jer)
 
->>>>>>> 886f2baaa805375e09bb5489a67ce8fee246cd31
     name_map = jec_stack_ak4.blank_name_map
     name_map["JetPt"] = "pt"
     name_map["JetMass"] = "mass"
@@ -198,7 +193,6 @@ def prepareJetsForFactory(isMC, events, jets):
         )
     jets["event_rho"] = ak.broadcast_arrays(events.fixedGridRhoFastjetAll, jets.pt)[0]
 
-<<<<<<< HEAD
     return jets
 
 def prepareScoutingJetsForFactory(isMC: int, era: str, events, jets):
@@ -211,10 +205,6 @@ def prepareScoutingJetsForFactory(isMC: int, era: str, events, jets):
     jets["event_rho"] = events.rho
     
     return jets
-=======
-    return jets  # , muon_pt
-
->>>>>>> 886f2baaa805375e09bb5489a67ce8fee246cd31
 
 def prepareMETForFactory(MET):
 
@@ -355,12 +345,7 @@ def getCorrectedMET(sample, isMC, era, events):
 
     return met_factory.build(met, alljets_forMET, lazy_cache=jec_cache)
 
-<<<<<<< HEAD
 def applyJECStoJets(sample, isMC, era, events, jets, jer: bool = False, scouting: bool = False, prefix: str = ""):
-=======
-
-def applyJECStoJets(sample, isMC, era, events, jets, jer: bool = False):
->>>>>>> 886f2baaa805375e09bb5489a67ce8fee246cd31
 
     jet_factory = getCorrectedJetsFactory(sample, isMC, era, jer=jer, prefix=prefix)
     jec_cache = cachetools.Cache(np.inf)
@@ -368,7 +353,6 @@ def applyJECStoJets(sample, isMC, era, events, jets, jer: bool = False):
     else: jets = prepareJetsForFactory(isMC, events, jets)
     jets_corrected = jet_factory.build(jets, lazy_cache=jec_cache)
     return jets_corrected
-<<<<<<< HEAD
 
 def getJECCorrectedAK4Jets(sample, isMC, era, events, jer: bool = False, scouting: bool = False, prefix: str = ""):
 
@@ -381,5 +365,3 @@ def getJECCorrectedAK4Jets(sample, isMC, era, events, jer: bool = False, scoutin
         jets = events.Jet
 
     return applyJECStoJets(sample, isMC, era, events, jets, jer=jer, scouting=scouting, prefix=prefix)
-=======
->>>>>>> 886f2baaa805375e09bb5489a67ce8fee246cd31

--- a/workflows/CMS_corrections/jetmet_utils.py
+++ b/workflows/CMS_corrections/jetmet_utils.py
@@ -1,64 +1,70 @@
+"""
+Implements the JEC and JER corrections for jets and MET in coffea.
+Follow the latest recommendations: https://cms-jerc.web.cern.ch/Recommendations/ 
+
+Authors: Chad Freer, Luca Lavezzo
+"""
+
 import awkward as ak
 import cachetools
 import numpy as np
 from coffea.jetmet_tools import CorrectedJetsFactory, CorrectedMETFactory, JECStack
 from coffea.lookup_tools import extractor
+import vector
+vector.register_awkward()
 
 
-def load_jets(self, events):
-    if (self.isMC == 1) and ("2016" in self.era):
-        vals_jet0 = events.OffJet
-        vals_jet0["pt_raw"] = events.OffJet.pt
-        vals_jet0["mass_raw"] = events.OffJet.mass
-        vals_jet0["pt_gen"] = ak.values_astype(
-            ak.without_parameters(ak.zeros_like(events.OffJet.pt)), np.float32
-        )
-        vals_jet0["event_rho"] = events.rho
-    else:
-        vals_jet0 = events.Jet
-        vals_jet0["pt_raw"] = events.Jet.pt
-        vals_jet0["mass_raw"] = events.Jet.mass
-        vals_jet0["event_rho"] = events.rho
-        vals_jet0["pt_gen"] = ak.values_astype(
-            ak.without_parameters(ak.zeros_like(events.Jet.pt)), np.float32
-        )
+# def load_jets(self, events):
+#     if (isMC == 1) and ("2016" in era):
+#         vals_jet0 = events.OffJet
+#         vals_jet0["pt_raw"] = events.OffJet.pt
+#         vals_jet0["mass_raw"] = events.OffJet.mass
+#         vals_jet0["pt_gen"] = ak.values_astype(
+#             ak.without_parameters(ak.zeros_like(events.OffJet.pt)), np.float32
+#         )
+#         vals_jet0["event_rho"] = events.rho
+#     else:
+#         vals_jet0 = events.Jet
+#         vals_jet0["pt_raw"] = events.Jet.pt
+#         vals_jet0["mass_raw"] = events.Jet.mass
+#         vals_jet0["event_rho"] = events.rho
+#         vals_jet0["pt_gen"] = ak.values_astype(
+#             ak.without_parameters(ak.zeros_like(events.Jet.pt)), np.float32
+#         )
 
-    return vals_jet0
+#     return vals_jet0
 
 
-def apply_jecs(self, Sample, events, prefix=""):
+def makeJECStack(Sample, isMC, era, prefix=""):
     """
-    Apply jet corrections to the jets in the events.
-    Returns the corrected jets and MET.
-    Follow the reccomendations: https://cms-jerc.web.cern.ch/Recommendations/ 
-    An example implentation in coffea: https://gitlab.cern.ch/gagarwal/ttbardileptonic/-/blob/master/jmeCorrections.py?ref_type=heads
+    Define the set of weights to use for JECs and JERs based on sample, isMC, and era.
     """
 
     # Find the Collection we want to look at
-    if int(self.isMC):
-        if str(self.era) == "2016":
+    if int(isMC):
+        if str(era) == "2016":
             jecdir = "Summer19UL16_V7_MC"
             jerdir = "Summer20UL16_JRV3_MC"
-        elif str(self.era) == "2016apv":
+        elif str(era) == "2016apv":
             jecdir = "Summer19UL16_V7_MC"
             jerdir = "Summer20UL16APV_JRV3_MC"
-        elif str(self.era) == "2017":
+        elif str(era) == "2017":
             jecdir = "Summer19UL17_V5_MC"
             jerdir = "Summer19UL17_JRV3_MC"
-        elif str(self.era) == "2018":
+        elif str(era) == "2018":
             jecdir = "Summer19UL18_V5_MC"
             jerdir = "Summer19UL18_JRV2_MC"
         else:
             raise Exception("Unable to find the correct JECs for MC!")
     # Now Data
-    elif not int(self.isMC):
-        if str(self.era) == "2016apv":
+    elif not int(isMC):
+        if str(era) == "2016apv":
             jecdir = "Summer19UL16APV_RunBCDEF_V7_DATA"
             jerdir = "Summer20UL16APV_JRV3_DATA"
-        elif str(self.era) == "2016":
+        elif str(era) == "2016":
             jecdir = "Summer19UL16_RunFGH_V7_DATA"
             jerdir = "Summer20UL16_JRV3_DATA"
-        elif str(self.era) == "2017":
+        elif str(era) == "2017":
             jerdir = "Summer19UL17_JRV3_DATA"
             if ("RunB" in Sample) or ("Run2017B" in Sample):
                 jecdir = "Summer19UL17_RunB_V5_DATA"
@@ -75,7 +81,7 @@ def apply_jecs(self, Sample, events, prefix=""):
                     "The JECs for the 2017 data era do not seem to exist! Found sample: "
                     + Sample
                 )
-        elif str(self.era) == "2018":
+        elif str(era) == "2018":
             jerdir = "Summer19UL18_JRV2_DATA"
             if ("RunA" in Sample) or ("Run2018A" in Sample):
                 jecdir = "Summer19UL18_RunA_V5_DATA"
@@ -92,21 +98,19 @@ def apply_jecs(self, Sample, events, prefix=""):
                 )
         else:
             raise Exception(
-                "Unable to find the correct JECs for Data! Found era: " + str(self.era)
+                "Unable to find the correct JECs for Data! Found era: " + str(era)
             )
     else:
         raise Exception(
             "Unable to determine if this is MC or Data! Found value of isMC: "
-            + str(self.isMC)
+            + str(isMC)
         )
 
-    # Start working here
     jec_path = prefix + "data/jetmet/JEC/" + jecdir + "/" + jecdir
     jer_path = prefix + "data/jetmet/JER/" + jerdir + "/" + jerdir
 
-    # Defined the weight sets we want to use
     ext_ak4 = extractor()
-    if self.isMC:
+    if isMC:
         ext_ak4.add_weight_sets(
             [ 
                 "* * " + jec_path + "_L1FastJet_AK4PFchs.jec.txt",  
@@ -131,14 +135,15 @@ def apply_jecs(self, Sample, events, prefix=""):
     ext_ak4.finalize()
     evaluator_ak4 = ext_ak4.make_evaluator()
 
-    if int(self.isMC):
+    # these are the weights that will be used
+    if int(isMC):
         jec_stack_names_ak4 = [
             jecdir + "_L1FastJet_AK4PFchs",
             jecdir + "_L2Relative_AK4PFchs",
             jecdir + "_L3Absolute_AK4PFchs",
             jecdir + "_Uncertainty_AK4PFchs",
-            jerdir + "_PtResolution_AK4PFchs",
-            jerdir + "_SF_AK4PFchs",
+            # jerdir + "_PtResolution_AK4PFchs", # TODO: do we apply JERS when calculating MET?
+            # jerdir + "_SF_AK4PFchs",
         ]
     else:
         jec_stack_names_ak4 = [
@@ -149,20 +154,13 @@ def apply_jecs(self, Sample, events, prefix=""):
         ]
 
     jec_inputs_ak4 = {name: evaluator_ak4[name] for name in jec_stack_names_ak4}
-    jec_stack_ak4 = JECStack(jec_inputs_ak4)
+    return JECStack(jec_inputs_ak4)
 
-    # Prepare the jets from the events
-    if int(self.scouting) == 1:
-        jets = load_jets(self, events)
-    else:
-        jets = events.Jet
-        jets["pt_raw"] = (1 - jets["rawFactor"]) * jets["pt"]
-        jets["mass_raw"] = (1 - jets["rawFactor"]) * jets["mass"]
-        if int(self.isMC):
-            jets["matched_gen_0p2"] = jets.nearest(events.GenJet, threshold=0.2)
-            jets["pt_gen"] = ak.values_astype(ak.fill_none(jets.matched_gen_0p2.pt, 0), np.float32)
-        jets["event_rho"] = ak.broadcast_arrays(events.fixedGridRhoFastjetAll, jets.pt)[0]
-    # Create the map (for both MC and data)
+
+def getCorrectedJetsFactory(Sample, isMC, era):
+
+    jec_stack_ak4 = makeJECStack(Sample, isMC, era)
+        
     name_map = jec_stack_ak4.blank_name_map
     name_map["JetPt"] = "pt"
     name_map["JetMass"] = "mass"
@@ -171,30 +169,161 @@ def apply_jecs(self, Sample, events, prefix=""):
     name_map["Rho"] = "event_rho"
     name_map["massRaw"] = "mass_raw"
     name_map["ptRaw"] = "pt_raw"
-    if int(self.isMC):
+    if int(isMC):
         name_map["ptGenJet"] = "pt_gen"
 
-    # create and return the corrected jet collection
+    return CorrectedJetsFactory(name_map, jec_stack_ak4)
+
+
+def getCorrectedMETFactory(Sample, isMC, era):
+
+    jec_stack_ak4 = makeJECStack(Sample, isMC, era)
+
+    name_map = jec_stack_ak4.blank_name_map
+    name_map["JetPt"] = "pt"
+    name_map["JetMass"] = "mass"
+    name_map["JetEta"] = "eta"
+    name_map["JetA"] = "area"
+    name_map["Rho"] = "event_rho"
+    name_map["massRaw"] = "mass_raw"
+    name_map["ptRaw"] = "pt_raw"
+    if int(isMC):
+        name_map["ptGenJet"] = "pt_gen"
+
+    name_map["METpt"] = "pt"
+    name_map["METphi"] = "phi"
+    name_map["JetPhi"] = "phi"
+    name_map["UnClusteredEnergyDeltaX"] = "MetUnclustEnUpDeltaX"
+    name_map["UnClusteredEnergyDeltaY"] = "MetUnclustEnUpDeltaY"
+
+    return CorrectedMETFactory(name_map)
+
+
+def prepareJetsForFactory(isMC, events, jets):
+
+    #jets["pt_raw"] = (1 - jets["rawFactor"]) * (1 - jets["muonSubtrFactor"]) * jets["pt"]
+    jets["pt_raw"] = (1 - jets["rawFactor"]) * jets["pt"]
+    jets["mass_raw"] = (1 - jets["rawFactor"]) * jets["mass"]
+    if int(isMC):
+        jets["matched_gen_0p2"] = jets.nearest(events.GenJet, threshold=0.2)
+        jets["pt_gen"] = ak.values_astype(ak.fill_none(jets.matched_gen_0p2.pt, 0), np.float32)
+    jets["event_rho"] = ak.broadcast_arrays(events.fixedGridRhoFastjetAll, jets.pt)[0]
+
+    # TODO: any explicit lepton subtraction to be done?
+    # muon_pt = jets["pt"] * (1 - jets["rawFactor"]) * jets["muonSubtrFactor"]
+
+    return jets #, muon_pt
+
+def prepareMETForFactory(MET):
+
+    met = ak.packed(MET, highlevel=True)
+    met["UnClusteredEnergyDeltaX"] = met["MetUnclustEnUpDeltaX"]
+    met["UnClusteredEnergyDeltaY"] = met["MetUnclustEnUpDeltaY"]
+
+    return MET
+
+def getJetsForMET(events):
+    """
+    These are the jets that are used to calculate the MET, not the ones for your analysis.
+    """
+    # TODO Do we need to use CorrT1METJet?
+    # TODO are our selections correct? (Do we need to do pt(1-muonSubtrFactor) > 15?)
+    # TODO Do we need to do lepton subtraction?
+    jets = events.Jet
+    jets = jets[(
+        (jets.pt * ( 1 - jets.muonSubtrFactor ) > 15) &
+        (jets.chEmEF + jets.neEmEF < 0.9) &
+        (jets.jetId > 0)
+    )]
+
+    # veto any jets that are in deltaR < 0.4 with any PF muon
+    jets_p4 = ak.zip({
+        "pt": jets.pt,
+        "eta": jets.eta,
+        "phi": jets.phi,
+        "mass": jets.mass,
+    }, with_name="Momentum4D")
+    muons_4p = ak.zip({
+        "pt": events.Muon.pt,
+        "eta": events.Muon.eta,
+        "phi": events.Muon.phi,
+        "mass": events.Muon.mass,
+    }, with_name="Momentum4D")
+    product = ak.cartesian({"jet": jets_p4, "muon": muons_4p}, nested=True)
+    jets = jets[ak.all(product.jet.deltaR(product.muon) >= 0.4, axis=-1)]
+
+    return jets
+
+def getCorrT1METJetForMET(events, isMC):
+
+    CorrT1METJet = events.CorrT1METJet
+
+    CorrT1METJet["pt_raw"] = CorrT1METJet["rawPt"]
+    CorrT1METJet["pt"] = CorrT1METJet["rawPt"]
+    CorrT1METJet["mass_raw"] = CorrT1METJet["rawPt"] * 0
+    CorrT1METJet["rawFactor"] = CorrT1METJet["rawPt"] * 0
+    CorrT1METJet["mass"] = CorrT1METJet["rawPt"] * 0
+    if int(isMC):
+        #CorrT1METJet["matched_gen_0p2"] = CorrT1METJet.nearest(events.GenJet, threshold=0.2)
+
+        # veto any jets that are in deltaR < 0.4 with any PF muon
+        CorrT1METJet_p4 = ak.zip({
+            "pt": CorrT1METJet.pt,
+            "eta": CorrT1METJet.eta,
+            "phi": CorrT1METJet.phi,
+            "mass": CorrT1METJet.mass,
+        }, with_name="Momentum4D")
+        genJet_4p = ak.zip({
+            "pt": events.GenJet.pt,
+            "eta": events.GenJet.eta,
+            "phi": events.GenJet.phi,
+            "mass": events.GenJet.mass,
+        }, with_name="Momentum4D")
+        product = ak.cartesian({"jet": CorrT1METJet_p4, "genJet": genJet_4p}, nested=True)
+        genJet_4p = genJet_4p[product.jet.deltaR(product.genJet) < 0.2]
+        CorrT1METJet["matched_gen_0p2"] = genJet_4p[ak.argmin(product.jet.deltaR(product.genJet), axis=-1)].pt
+
+        CorrT1METJet["pt_gen"] = ak.values_astype(ak.fill_none(CorrT1METJet.matched_gen_0p2.pt, 0), np.float32)
+    CorrT1METJet["event_rho"] = ak.broadcast_arrays(events.fixedGridRhoFastjetAll, CorrT1METJet.pt_raw)[0]
+
+    CorrT1METJet = CorrT1METJet[(
+        (CorrT1METJet.pt * ( 1 - CorrT1METJet.muonSubtrFactor ) > 15)
+    )]
+
+    # veto any CorrT1METJet that are in deltaR < 0.4 with any PF muon
+    CorrT1METJet_p4 = ak.zip({
+        "pt": CorrT1METJet.pt,
+        "eta": CorrT1METJet.eta,
+        "phi": CorrT1METJet.phi,
+        "mass": CorrT1METJet.mass,
+    }, with_name="Momentum4D")
+    muons_4p = ak.zip({
+        "pt": events.Muon.pt,
+        "eta": events.Muon.eta,
+        "phi": events.Muon.phi,
+        "mass": events.Muon.mass,
+    }, with_name="Momentum4D")
+    product = ak.cartesian({"jet": CorrT1METJet_p4, "muon": muons_4p}, nested=True)
+    CorrT1METJet = CorrT1METJet[ak.all(product.jet.deltaR(product.muon) >= 0.4, axis=-1)]
+
+    return CorrT1METJet
+
+def getCorrectedMET(sample, isMC, era, events):
+
+    met_factory = getCorrectedMETFactory(sample, isMC, era)
+    met = prepareMETForFactory(events.MET)
     jec_cache = cachetools.Cache(np.inf)
-    jet_factory = CorrectedJetsFactory(name_map, jec_stack_ak4)
-    corrected_jets = jet_factory.build(jets, lazy_cache=jec_cache)
+    jets_forMET = getJetsForMET(events)
+    jets_forMET = prepareJetsForFactory(isMC, events, jets_forMET)
+    CorrT1METJet_forMET = getCorrT1METJetForMET(events, isMC)
+    alljets_forMET = ak.concatenate([jets_forMET, CorrT1METJet_forMET], axis=1)
+    corrected_jets_forMET = applyJECStoJets(sample, isMC, era, events, alljets_forMET) 
+    return met_factory.build(met, corrected_jets_forMET, lazy_cache=jec_cache)
 
-    if self.scouting == 1:
-        return corrected_jets, None
+def applyJECStoJets(sample, isMC, era, events, jets):
 
-    else:
-        name_map["METpt"] = "pt"
-        name_map["METphi"] = "phi"
-        name_map["JetPhi"] = "phi"
-        name_map["UnClusteredEnergyDeltaX"] = "MetUnclustEnUpDeltaX"
-        name_map["UnClusteredEnergyDeltaY"] = "MetUnclustEnUpDeltaY"
-
-        met_factory = CorrectedMETFactory(name_map)
-        met = ak.packed(events.MET, highlevel=True)
-        met["pt"] = met["pt"]
-        met["phi"] = met["phi"]
-        met["UnClusteredEnergyDeltaX"] = met["MetUnclustEnUpDeltaX"]
-        met["UnClusteredEnergyDeltaY"] = met["MetUnclustEnUpDeltaY"]
-        corrected_met = met_factory.build(met, corrected_jets, lazy_cache=jec_cache)
-
-        return corrected_jets, corrected_met
+    jet_factory = getCorrectedJetsFactory(sample, isMC, era)
+    jec_cache = cachetools.Cache(np.inf)
+    jets = prepareJetsForFactory(isMC, events, jets)
+    jets_corrected = jet_factory.build(jets, lazy_cache=jec_cache)
+    return jets_corrected

--- a/workflows/SUEP_coffea.py
+++ b/workflows/SUEP_coffea.py
@@ -20,7 +20,7 @@ import workflows.ZH_utils as ZH_utils
 # Importing CMS corrections
 from workflows.CMS_corrections.golden_jsons_utils import applyGoldenJSON
 from workflows.CMS_corrections.HEM_utils import jetHEMFilter
-from workflows.CMS_corrections.jetmet_utils import applyJECStoJets
+from workflows.CMS_corrections.jetmet_utils import getJECCorrectedAK4Jets
 from workflows.CMS_corrections.PartonShower_utils import GetPSWeights
 from workflows.CMS_corrections.Prefire_utils import GetPrefireWeights
 from workflows.CMS_corrections.track_killing_utils import (
@@ -378,7 +378,7 @@ class SUEP_cluster(processor.ProcessorABC):
         if self.accum:
             if "dask" in self.accum:
                 prefix = "dask-worker-space/"
-        jets_c = applyJECStoJets(sample=self.sample, isMC=self.isMC, era=self.era, events=events, jets=events.Jet, jer=self.isMC)
+        jets_c = getJECCorrectedAK4Jets(self.sample, self.isMC, self.era, events, jer = self.isMC, scouting = self.scouting, prefix=prefix)
         jet_HEM_Cut, _ = jetHEMFilter(self, jets_c, events.run)
         jets_c = jets_c[jet_HEM_Cut]
         jets_jec = self.jet_awkward(jets_c)

--- a/workflows/SUEP_coffea.py
+++ b/workflows/SUEP_coffea.py
@@ -20,7 +20,7 @@ import workflows.ZH_utils as ZH_utils
 # Importing CMS corrections
 from workflows.CMS_corrections.golden_jsons_utils import applyGoldenJSON
 from workflows.CMS_corrections.HEM_utils import jetHEMFilter
-from workflows.CMS_corrections.jetmet_utils import apply_jecs
+from workflows.CMS_corrections.jetmet_utils import applyJECStoJets
 from workflows.CMS_corrections.PartonShower_utils import GetPSWeights
 from workflows.CMS_corrections.Prefire_utils import GetPrefireWeights
 from workflows.CMS_corrections.track_killing_utils import (
@@ -378,9 +378,7 @@ class SUEP_cluster(processor.ProcessorABC):
         if self.accum:
             if "dask" in self.accum:
                 prefix = "dask-worker-space/"
-        jets_c, met_c = apply_jecs(
-            self, Sample=self.sample, events=events, prefix=prefix
-        )
+        jets_c = applyJECStoJets(sample=self.sample, isMC=self.isMC, era=self.era, events=events, jets=events.Jet, jer=self.isMC)
         jet_HEM_Cut, _ = jetHEMFilter(self, jets_c, events.run)
         jets_c = jets_c[jet_HEM_Cut]
         jets_jec = self.jet_awkward(jets_c)

--- a/workflows/SUEP_coffea_WH.py
+++ b/workflows/SUEP_coffea_WH.py
@@ -514,10 +514,10 @@ class SUEP_cluster_WH(processor.ProcessorABC):
         )[:, 0]
 
         # save MET
-        self.MET = WH_utils.make_MET_4v(events.MET)
+        self.MET = WH_utils.make_MET_4v(met_c)
 
         # saving kinematic variables for the deltaphi(min(jet,MET)) jet
-        self.jets_jec.deltaPhiMET = WH_utils.MET_delta_phi(self.jets_jec, events.MET)
+        self.jets_jec.deltaPhiMET = WH_utils.MET_delta_phi(self.jets_jec, self.MET)
         sorted_deltaphiMET_jets = self.jets_jec[
             ak.argsort(self.jets_jec.deltaPhiMET, axis=1, ascending=True)
         ]
@@ -558,9 +558,11 @@ class SUEP_cluster_WH(processor.ProcessorABC):
         output["vars"]["RawMET_sumEt"] = events.RawMET.sumEt
         output["vars"]["RawPuppiMET_pt"] = events.RawPuppiMET.pt
         output["vars"]["RawPuppiMET_phi"] = events.RawPuppiMET.phi
+        """
+        output["vars"]["MET_JEC_phi"] = met_c.phi
         output["vars"]["MET_JEC_pt"] = met_c.pt
         output["vars"]["MET_JEC_sumEt"] = met_c.sumEt
-        """
+        
 
         # corrections on MET
         if self.isMC and self.do_syst:
@@ -683,12 +685,12 @@ class SUEP_cluster_WH(processor.ProcessorABC):
             )[:, i]
 
         # saving W information
-        self.W = WH_utils.make_Wt_4v(self.lepton, events.MET)
+        self.W = WH_utils.make_Wt_4v(self.lepton, self.MET)
         self.W_PuppiMET = WH_utils.make_Wt_4v(self.lepton, events.PuppiMET)
         self.W_CaloMET = WH_utils.make_Wt_4v(self.lepton, events.CaloMET)
         output["vars"]["W_pt"] = self.W.pt
         output["vars"]["W_phi"] = self.W.phi
-        output["vars"]["W_mt"] = WH_utils.calc_W_mt(self.lepton, events.MET)
+        output["vars"]["W_mt"] = WH_utils.calc_W_mt(self.lepton, self.MET)
         output["vars"]["W_pt_PuppiMET"] = self.W_PuppiMET.pt
         output["vars"]["W_phi_PuppiMET"] = self.W_PuppiMET.phi
         output["vars"]["W_mt_PuppiMET"] = WH_utils.calc_W_mt(

--- a/workflows/SUEP_coffea_WH.py
+++ b/workflows/SUEP_coffea_WH.py
@@ -408,12 +408,8 @@ class SUEP_cluster_WH(processor.ProcessorABC):
         output["vars"]["PV_npvs"] = events.PV.npvs
         output["vars"]["PV_npvsGood"] = events.PV.npvsGood
 
-        if self.isMC:
-            output["vars"]["LHE_Vpt"] = events.LHE.Vpt
-            output["vars"]["LHE_HT"] = events.LHE.HT
-
         # select out ak4jets
-        uncorrected_ak4jets = WH_utils.getAK4Jets(events.Jet, isMC=self.isMC)
+        uncorrected_ak4jets = WH_utils.getAK4Jets(events.Jet, self.lepton, isMC=self.isMC)
         jets_c, met_c = apply_jecs(
             self,
             Sample=self.sample,
@@ -427,6 +423,8 @@ class SUEP_cluster_WH(processor.ProcessorABC):
 
         # ht
         output["vars"]["ht"] = ak.sum(uncorrected_ak4jets.pt, axis=-1).to_list()
+        output["vars"]["nuncorrected_ak4jets"] = ak.num(uncorrected_ak4jets).to_list()
+
         output["vars"]["ht_JEC"] = ak.sum(self.jets_jec.pt, axis=-1).to_list()
         if self.isMC and self.do_syst:
             jets_jec_JERUp = WH_utils.getAK4Jets(
@@ -544,25 +542,8 @@ class SUEP_cluster_WH(processor.ProcessorABC):
         output["vars"]["MET_pt"] = events.MET.pt
         output["vars"]["MET_phi"] = events.MET.phi
         output["vars"]["MET_sumEt"] = events.MET.sumEt
-
-        # deprecated
-        """
-        output["vars"]["ChsMET_pt"] = events.ChsMET.pt
-        output["vars"]["ChsMET_phi"] = events.ChsMET.phi
-        output["vars"]["ChsMET_sumEt"] = events.ChsMET.sumEt
-        output["vars"]["TkMET_pt"] = events.TkMET.pt
-        output["vars"]["TkMET_phi"] = events.TkMET.phi
-        output["vars"]["TkMET_sumEt"] = events.TkMET.sumEt
-        output["vars"]["RawMET_pt"] = events.RawMET.pt
-        output["vars"]["RawMET_phi"] = events.RawMET.phi
-        output["vars"]["RawMET_sumEt"] = events.RawMET.sumEt
-        output["vars"]["RawPuppiMET_pt"] = events.RawPuppiMET.pt
-        output["vars"]["RawPuppiMET_phi"] = events.RawPuppiMET.phi
-        """
-        output["vars"]["MET_JEC_phi"] = met_c.phi
-        output["vars"]["MET_JEC_pt"] = met_c.pt
-        output["vars"]["MET_JEC_sumEt"] = met_c.sumEt
-        
+        output["vars"]["MET_JEC_phi"] = self.MET.phi
+        output["vars"]["MET_JEC_pt"] = self.MET.pt
 
         # corrections on MET
         if self.isMC and self.do_syst:


### PR DESCRIPTION
- remove L1RC and L2 residual from data weights in JECs
- for MC JECs, do gen matching with dR = 0.2 instead of default in NANO
- turn off CorrectedMETFactory