### PR TITLE
Update xsections_2017.json

### DIFF
--- a/data/xsections_2017.json
+++ b/data/xsections_2017.json
@@ -11458,5 +11458,23 @@
     "kr": 1,
     "xsec": 1.358,
     "signal": 1
+  },
+  "WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
+    "br": 1,
+    "kr": 1,
+    "xsec": 52780.0,
+    "signal": 0
+  },
+  "WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2+MINIAODSIM": {
+    "br": 1,
+    "kr": 1,
+    "xsec": 8832.0,
+    "signal": 0
+  },
+  "WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1+MINIAODSIM": {
+    "br": 1,
+    "kr": 1,
+    "xsec": 3276.0,
+    "signal": 0
   }
 }


### PR DESCRIPTION
added n-jet binned sample info using br and kr = 1 and signal = 0